### PR TITLE
fix(Signup): using min-height instead of max-height

### DIFF
--- a/assets/stylesheets/_components--modal.scss
+++ b/assets/stylesheets/_components--modal.scss
@@ -1,0 +1,5 @@
+.modal {
+  .modal-header {
+    padding: 5px 10px;
+  }
+}

--- a/assets/stylesheets/_components--signup-form.scss
+++ b/assets/stylesheets/_components--signup-form.scss
@@ -1,4 +1,4 @@
-$signup-max-height: 550px;
+$signup-min-height: 550px;
 
 .d-modal.create-account,
 .d-modal.login-modal {
@@ -25,7 +25,7 @@ $signup-max-height: 550px;
     }
 
     form {
-      max-height: $signup-max-height;
+      min-height: $signup-min-height;
       padding: 0 15px;
 
       tr {

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -25,3 +25,4 @@
 @import "components--navigation";
 @import "components--header-link";
 @import "components--signup-form";
+@import "components--modal";


### PR DESCRIPTION
fixes user fields rendering one of top of the other.

Closes debtcollective/community#6

## Media

**iPhone 6s**
![iphone6s](https://user-images.githubusercontent.com/849872/55115567-6d4dfa00-50aa-11e9-81d5-b7faf69d6b6c.png)

**Galaxy S9**
![galaxys9](https://user-images.githubusercontent.com/849872/55115568-6d4dfa00-50aa-11e9-947d-0192fc7b6ef7.png)
