### PR TITLE
Fix: signup fields and modal issues

### DIFF
--- a/assets/javascripts/discourse/initializers/html-classes.js.es6
+++ b/assets/javascripts/discourse/initializers/html-classes.js.es6
@@ -1,0 +1,173 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+import { on } from "ember-addons/ember-computed-decorators";
+
+// https://github.com/framework7io/framework7/blob/master/src/core/utils/device.js
+const getDeviceInfo = () => {
+  const Support = {
+    touch: (function checkTouch() {
+      return !!(
+        window.navigator.maxTouchPoints > 0 ||
+        "ontouchstart" in window ||
+        (window.DocumentTouch && document instanceof window.DocumentTouch)
+      );
+    })()
+  };
+  const platform = window.navigator.platform;
+  const ua = window.navigator.userAgent;
+
+  const device = {
+    ios: false,
+    android: false,
+    androidChrome: false,
+    desktop: false,
+    windowsPhone: false,
+    iphone: false,
+    iphoneX: false,
+    ipod: false,
+    ipad: false,
+    edge: false,
+    ie: false,
+    firefox: false,
+    macos: false,
+    windows: false,
+    cordova: !!(window.cordova || window.phonegap),
+    phonegap: !!(window.cordova || window.phonegap),
+    electron: false
+  };
+
+  const screenWidth = window.screen.width;
+  const screenHeight = window.screen.height;
+
+  const windowsPhone = ua.match(/(Windows Phone);?[\s\/]+([\d.]+)?/); // eslint-disable-line
+  const android = ua.match(/(Android);?[\s\/]+([\d.]+)?/); // eslint-disable-line
+  let ipad = ua.match(/(iPad).*OS\s([\d_]+)/);
+  const ipod = ua.match(/(iPod)(.*OS\s([\d_]+))?/);
+  const iphone = !ipad && ua.match(/(iPhone\sOS|iOS)\s([\d_]+)/);
+  const iphoneX =
+    iphone &&
+    ((screenWidth === 375 && screenHeight === 812) || // X/XS
+      (screenWidth === 414 && screenHeight === 896)); // XR / XS Max
+  const ie = ua.indexOf("MSIE ") >= 0 || ua.indexOf("Trident/") >= 0;
+  const edge = ua.indexOf("Edge/") >= 0;
+  const firefox = ua.indexOf("Gecko/") >= 0 && ua.indexOf("Firefox/") >= 0;
+  const windows = platform === "Win32";
+  const electron = ua.toLowerCase().indexOf("electron") >= 0;
+  let macos = platform === "MacIntel";
+
+  // iPadOs 13 fix
+  if (
+    !ipad &&
+    macos &&
+    Support.touch &&
+    ((screenWidth === 1024 && screenHeight === 1366) || // Pro 12.9
+    (screenWidth === 834 && screenHeight === 1194) || // Pro 11
+    (screenWidth === 834 && screenHeight === 1112) || // Pro 10.5
+      (screenWidth === 768 && screenHeight === 1024)) // other
+  ) {
+    ipad = ua.match(/(Version)\/([\d.]+)/);
+    macos = false;
+  }
+
+  device.ie = ie;
+  device.edge = edge;
+  device.firefox = firefox;
+
+  // Windows
+  if (windowsPhone) {
+    device.os = "windowsPhone";
+    device.osVersion = windowsPhone[2];
+    device.windowsPhone = true;
+  }
+  // Android
+  if (android && !windows) {
+    device.os = "android";
+    device.osVersion = android[2];
+    device.android = true;
+    device.androidChrome = ua.toLowerCase().indexOf("chrome") >= 0;
+  }
+  if (ipad || iphone || ipod) {
+    device.os = "ios";
+    device.ios = true;
+  }
+  // iOS
+  if (iphone && !ipod) {
+    device.osVersion = iphone[2].replace(/_/g, ".");
+    device.iphone = true;
+    device.iphoneX = iphoneX;
+  }
+  if (ipad) {
+    device.osVersion = ipad[2].replace(/_/g, ".");
+    device.ipad = true;
+  }
+  if (ipod) {
+    device.osVersion = ipod[3] ? ipod[3].replace(/_/g, ".") : null;
+    device.ipod = true;
+  }
+  // iOS 8+ changed UA
+  if (device.ios && device.osVersion && ua.indexOf("Version/") >= 0) {
+    if (device.osVersion.split(".")[0] === "10") {
+      device.osVersion = ua
+        .toLowerCase()
+        .split("version/")[1]
+        .split(" ")[0];
+    }
+  }
+
+  // Webview
+  device.webView =
+    !!(
+      (iphone || ipad || ipod) &&
+      (ua.match(/.*AppleWebKit(?!.*Safari)/i) || window.navigator.standalone)
+    ) ||
+    (window.matchMedia &&
+      window.matchMedia("(display-mode: standalone)").matches);
+  device.webview = device.webView;
+  device.standalone = device.webView;
+
+  // Desktop
+  device.desktop =
+    !(device.ios || device.android || device.windowsPhone) || electron;
+  if (device.desktop) {
+    device.electron = electron;
+    device.macos = macos;
+    device.windows = windows;
+    if (device.macos) {
+      device.os = "macos";
+    }
+    if (device.windows) {
+      device.os = "windows";
+    }
+  }
+
+  // Pixel Ratio
+  device.pixelRatio = window.devicePixelRatio || 1;
+
+  return device;
+};
+
+export default {
+  name: "debtcollective-html-classes",
+  initialize() {
+    withPluginApi("0.8.9", api => {
+      api.modifyClass("component:site-header", {
+        @on("init")
+        addDeviceHTMLClasses() {
+          const device = getDeviceInfo();
+          const supportOverflowClass =
+            Number(device.os) >= 13
+              ? "support-overflow-hidden"
+              : "not-support-overflow-hidden";
+          const osClass = `device-${device.os}`;
+          const osVersionClass = !device.desktop
+            ? `${osClass} ${osClass}-${device.osVersion.replace(/\./g, "-")}`
+            : "";
+
+          // Ideally, follow the expectations from https://framework7.io/docs/device.html
+          $("html").addClass(
+            `${osClass} ${osVersionClass} ${supportOverflowClass}`
+          );
+        }
+      });
+    });
+  }
+};

--- a/assets/javascripts/discourse/initializers/html-classes.js.es6
+++ b/assets/javascripts/discourse/initializers/html-classes.js.es6
@@ -1,148 +1,20 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { on } from "ember-addons/ember-computed-decorators";
+import Device from "../../helpers/device";
 
-// https://github.com/framework7io/framework7/blob/master/src/core/utils/device.js
-const getDeviceInfo = () => {
-  const Support = {
-    touch: (function checkTouch() {
-      return !!(
-        window.navigator.maxTouchPoints > 0 ||
-        "ontouchstart" in window ||
-        (window.DocumentTouch && document instanceof window.DocumentTouch)
-      );
-    })()
-  };
-  const platform = window.navigator.platform;
-  const ua = window.navigator.userAgent;
-
-  const device = {
-    ios: false,
-    android: false,
-    androidChrome: false,
-    desktop: false,
-    windowsPhone: false,
-    iphone: false,
-    iphoneX: false,
-    ipod: false,
-    ipad: false,
-    edge: false,
-    ie: false,
-    firefox: false,
-    macos: false,
-    windows: false,
-    cordova: !!(window.cordova || window.phonegap),
-    phonegap: !!(window.cordova || window.phonegap),
-    electron: false
-  };
-
-  const screenWidth = window.screen.width;
-  const screenHeight = window.screen.height;
-
-  const windowsPhone = ua.match(/(Windows Phone);?[\s\/]+([\d.]+)?/); // eslint-disable-line
-  const android = ua.match(/(Android);?[\s\/]+([\d.]+)?/); // eslint-disable-line
-  let ipad = ua.match(/(iPad).*OS\s([\d_]+)/);
-  const ipod = ua.match(/(iPod)(.*OS\s([\d_]+))?/);
-  const iphone = !ipad && ua.match(/(iPhone\sOS|iOS)\s([\d_]+)/);
-  const iphoneX =
-    iphone &&
-    ((screenWidth === 375 && screenHeight === 812) || // X/XS
-      (screenWidth === 414 && screenHeight === 896)); // XR / XS Max
-  const ie = ua.indexOf("MSIE ") >= 0 || ua.indexOf("Trident/") >= 0;
-  const edge = ua.indexOf("Edge/") >= 0;
-  const firefox = ua.indexOf("Gecko/") >= 0 && ua.indexOf("Firefox/") >= 0;
-  const windows = platform === "Win32";
-  const electron = ua.toLowerCase().indexOf("electron") >= 0;
-  let macos = platform === "MacIntel";
-
-  // iPadOs 13 fix
-  if (
-    !ipad &&
-    macos &&
-    Support.touch &&
-    ((screenWidth === 1024 && screenHeight === 1366) || // Pro 12.9
-    (screenWidth === 834 && screenHeight === 1194) || // Pro 11
-    (screenWidth === 834 && screenHeight === 1112) || // Pro 10.5
-      (screenWidth === 768 && screenHeight === 1024)) // other
-  ) {
-    ipad = ua.match(/(Version)\/([\d.]+)/);
-    macos = false;
+const getiOSClasses = () => {
+  if (Device.desktop || Device.os !== "ios") {
+    return "";
   }
 
-  device.ie = ie;
-  device.edge = edge;
-  device.firefox = firefox;
+  const supportOverflowClass =
+    Number(Device.osVersion) >= 13
+      ? "support-overflow-hidden"
+      : "not-support-overflow-hidden";
+  const osClass = `device-${Device.os}`;
+  const osVersionClass = `${osClass}-${Device.osVersion.split(".")[0]}`;
 
-  // Windows
-  if (windowsPhone) {
-    device.os = "windowsPhone";
-    device.osVersion = windowsPhone[2];
-    device.windowsPhone = true;
-  }
-  // Android
-  if (android && !windows) {
-    device.os = "android";
-    device.osVersion = android[2];
-    device.android = true;
-    device.androidChrome = ua.toLowerCase().indexOf("chrome") >= 0;
-  }
-  if (ipad || iphone || ipod) {
-    device.os = "ios";
-    device.ios = true;
-  }
-  // iOS
-  if (iphone && !ipod) {
-    device.osVersion = iphone[2].replace(/_/g, ".");
-    device.iphone = true;
-    device.iphoneX = iphoneX;
-  }
-  if (ipad) {
-    device.osVersion = ipad[2].replace(/_/g, ".");
-    device.ipad = true;
-  }
-  if (ipod) {
-    device.osVersion = ipod[3] ? ipod[3].replace(/_/g, ".") : null;
-    device.ipod = true;
-  }
-  // iOS 8+ changed UA
-  if (device.ios && device.osVersion && ua.indexOf("Version/") >= 0) {
-    if (device.osVersion.split(".")[0] === "10") {
-      device.osVersion = ua
-        .toLowerCase()
-        .split("version/")[1]
-        .split(" ")[0];
-    }
-  }
-
-  // Webview
-  device.webView =
-    !!(
-      (iphone || ipad || ipod) &&
-      (ua.match(/.*AppleWebKit(?!.*Safari)/i) || window.navigator.standalone)
-    ) ||
-    (window.matchMedia &&
-      window.matchMedia("(display-mode: standalone)").matches);
-  device.webview = device.webView;
-  device.standalone = device.webView;
-
-  // Desktop
-  device.desktop =
-    !(device.ios || device.android || device.windowsPhone) || electron;
-  if (device.desktop) {
-    device.electron = electron;
-    device.macos = macos;
-    device.windows = windows;
-    if (device.macos) {
-      device.os = "macos";
-    }
-    if (device.windows) {
-      device.os = "windows";
-    }
-  }
-
-  // Pixel Ratio
-  device.pixelRatio = window.devicePixelRatio || 1;
-
-  return device;
+  return `${osClass} ${osVersionClass} ${supportOverflowClass}`;
 };
 
 export default {
@@ -152,20 +24,8 @@ export default {
       api.modifyClass("component:site-header", {
         @on("init")
         addDeviceHTMLClasses() {
-          const device = getDeviceInfo();
-          const supportOverflowClass =
-            Number(device.os) >= 13
-              ? "support-overflow-hidden"
-              : "not-support-overflow-hidden";
-          const osClass = `device-${device.os}`;
-          const osVersionClass = !device.desktop
-            ? `${osClass} ${osClass}-${device.osVersion.replace(/\./g, "-")}`
-            : "";
-
-          // Ideally, follow the expectations from https://framework7.io/docs/device.html
-          $("html").addClass(
-            `${osClass} ${osVersionClass} ${supportOverflowClass}`
-          );
+          const iOSClasses = getiOSClasses();
+          $("html").addClass(iOSClasses);
         }
       });
     });

--- a/assets/javascripts/discourse/initializers/html-classes.js.es6
+++ b/assets/javascripts/discourse/initializers/html-classes.js.es6
@@ -2,19 +2,11 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 import { on } from "ember-addons/ember-computed-decorators";
 import Device from "../../helpers/device";
 
-const getiOSClasses = () => {
-  if (Device.desktop || Device.os !== "ios") {
-    return "";
-  }
-
-  const supportOverflowClass =
-    Number(Device.osVersion) >= 13
-      ? "support-overflow-hidden"
-      : "not-support-overflow-hidden";
-  const osClass = `device-${Device.os}`;
-  const osVersionClass = `${osClass}-${Device.osVersion.split(".")[0]}`;
-
-  return `${osClass} ${osVersionClass} ${supportOverflowClass}`;
+const getSupportOverflowClass = () => {
+  const majorVersion = Device.osVersion && Device.osVersion.split(".")[0];
+  return (Device.os === "ios" && majorVersion >= 13) || Device.desktop
+    ? "support-overflow-hidden"
+    : "not-support-overflow-hidden";
 };
 
 export default {
@@ -24,8 +16,8 @@ export default {
       api.modifyClass("component:site-header", {
         @on("init")
         addDeviceHTMLClasses() {
-          const iOSClasses = getiOSClasses();
-          $("html").addClass(iOSClasses);
+          const overflowClass = getSupportOverflowClass();
+          $("html").addClass(overflowClass);
         }
       });
     });

--- a/assets/javascripts/helpers/device.js.es6
+++ b/assets/javascripts/helpers/device.js.es6
@@ -1,0 +1,155 @@
+/**
+ * All the code below has been extracted from framework7io
+ * the idea is to keep it as it is in order to make it easier to update
+ * in case it's needed.
+ *
+ * NOTE: Discourse already does something similar within their application_helper#html_classes
+ * nevertheless, it is more complex to update.
+ */
+
+const Support = {
+  touch: (function checkTouch() {
+    return !!(
+      window.navigator.maxTouchPoints > 0 ||
+      "ontouchstart" in window ||
+      (window.DocumentTouch && document instanceof window.DocumentTouch)
+    );
+  })()
+};
+
+// https://github.com/framework7io/framework7/blob/master/src/core/utils/device.js
+const Device = (function Device() {
+  const platform = window.navigator.platform;
+  const ua = window.navigator.userAgent;
+
+  const device = {
+    ios: false,
+    android: false,
+    androidChrome: false,
+    desktop: false,
+    windowsPhone: false,
+    iphone: false,
+    iphoneX: false,
+    ipod: false,
+    ipad: false,
+    edge: false,
+    ie: false,
+    firefox: false,
+    macos: false,
+    windows: false,
+    cordova: !!(window.cordova || window.phonegap),
+    phonegap: !!(window.cordova || window.phonegap),
+    electron: false
+  };
+
+  const screenWidth = window.screen.width;
+  const screenHeight = window.screen.height;
+
+  const windowsPhone = ua.match(/(Windows Phone);?[\s\/]+([\d.]+)?/); // eslint-disable-line
+  const android = ua.match(/(Android);?[\s\/]+([\d.]+)?/); // eslint-disable-line
+  let ipad = ua.match(/(iPad).*OS\s([\d_]+)/);
+  const ipod = ua.match(/(iPod)(.*OS\s([\d_]+))?/);
+  const iphone = !ipad && ua.match(/(iPhone\sOS|iOS)\s([\d_]+)/);
+  const iphoneX =
+    iphone &&
+    ((screenWidth === 375 && screenHeight === 812) || // X/XS
+      (screenWidth === 414 && screenHeight === 896)); // XR / XS Max
+  const ie = ua.indexOf("MSIE ") >= 0 || ua.indexOf("Trident/") >= 0;
+  const edge = ua.indexOf("Edge/") >= 0;
+  const firefox = ua.indexOf("Gecko/") >= 0 && ua.indexOf("Firefox/") >= 0;
+  const windows = platform === "Win32";
+  const electron = ua.toLowerCase().indexOf("electron") >= 0;
+  let macos = platform === "MacIntel";
+
+  // iPadOs 13 fix
+  if (
+    !ipad &&
+    macos &&
+    Support.touch &&
+    ((screenWidth === 1024 && screenHeight === 1366) || // Pro 12.9
+    (screenWidth === 834 && screenHeight === 1194) || // Pro 11
+    (screenWidth === 834 && screenHeight === 1112) || // Pro 10.5
+      (screenWidth === 768 && screenHeight === 1024)) // other
+  ) {
+    ipad = ua.match(/(Version)\/([\d.]+)/);
+    macos = false;
+  }
+
+  device.ie = ie;
+  device.edge = edge;
+  device.firefox = firefox;
+
+  // Windows
+  if (windowsPhone) {
+    device.os = "windowsPhone";
+    device.osVersion = windowsPhone[2];
+    device.windowsPhone = true;
+  }
+  // Android
+  if (android && !windows) {
+    device.os = "android";
+    device.osVersion = android[2];
+    device.android = true;
+    device.androidChrome = ua.toLowerCase().indexOf("chrome") >= 0;
+  }
+  if (ipad || iphone || ipod) {
+    device.os = "ios";
+    device.ios = true;
+  }
+  // iOS
+  if (iphone && !ipod) {
+    device.osVersion = iphone[2].replace(/_/g, ".");
+    device.iphone = true;
+    device.iphoneX = iphoneX;
+  }
+  if (ipad) {
+    device.osVersion = ipad[2].replace(/_/g, ".");
+    device.ipad = true;
+  }
+  if (ipod) {
+    device.osVersion = ipod[3] ? ipod[3].replace(/_/g, ".") : null;
+    device.ipod = true;
+  }
+  // iOS 8+ changed UA
+  if (device.ios && device.osVersion && ua.indexOf("Version/") >= 0) {
+    if (device.osVersion.split(".")[0] === "10") {
+      device.osVersion = ua
+        .toLowerCase()
+        .split("version/")[1]
+        .split(" ")[0];
+    }
+  }
+
+  // Webview
+  device.webView =
+    !!(
+      (iphone || ipad || ipod) &&
+      (ua.match(/.*AppleWebKit(?!.*Safari)/i) || window.navigator.standalone)
+    ) ||
+    (window.matchMedia &&
+      window.matchMedia("(display-mode: standalone)").matches);
+  device.webview = device.webView;
+  device.standalone = device.webView;
+
+  // Desktop
+  device.desktop =
+    !(device.ios || device.android || device.windowsPhone) || electron;
+  if (device.desktop) {
+    device.electron = electron;
+    device.macos = macos;
+    device.windows = windows;
+    if (device.macos) {
+      device.os = "macos";
+    }
+    if (device.windows) {
+      device.os = "windows";
+    }
+  }
+
+  // Pixel Ratio
+  device.pixelRatio = window.devicePixelRatio || 1;
+  // Export object
+  return device;
+})();
+
+export default Device;

--- a/assets/stylesheets/_components--modal.scss
+++ b/assets/stylesheets/_components--modal.scss
@@ -3,3 +3,9 @@
     padding: 5px 10px;
   }
 }
+
+// Avoid double scroll on all browsers but Safari iOS <= 12
+body.modal-open {
+  height: 100%;
+  overflow: hidden; 
+}

--- a/assets/stylesheets/_components--modal.scss
+++ b/assets/stylesheets/_components--modal.scss
@@ -4,6 +4,13 @@
   }
 }
 
+// Use percentages instead vh units to limit modal height and avoid iOS issues
+.modal-inner-container,
+.fixed-modal .modal-inner-container {
+  max-height: 90%;
+  margin-bottom: 0;
+}
+
 // Avoid double scroll on all browsers but Safari iOS <= 12
 body.modal-open {
   height: 100%;

--- a/assets/stylesheets/_layouts--body.scss
+++ b/assets/stylesheets/_layouts--body.scss
@@ -5,9 +5,7 @@ body {
 // Reset the Discourse core CSS code to avoid scroll issues
 html {
   overflow-y: initial;
-}
-
-html.device-ios {
+  
   &.not-support-overflow-hidden {
     body.modal-open { 
       position: fixed;

--- a/assets/stylesheets/_layouts--body.scss
+++ b/assets/stylesheets/_layouts--body.scss
@@ -6,3 +6,12 @@ body {
 html {
   overflow-y: initial;
 }
+
+html.device-ios {
+  &.not-support-overflow-hidden {
+    body.modal-open { 
+      position: fixed;
+      width: 100%;
+    }
+  }
+}

--- a/assets/stylesheets/_layouts--body.scss
+++ b/assets/stylesheets/_layouts--body.scss
@@ -1,3 +1,8 @@
 body {
   background: linear-gradient(color("bg-blue"), color("bg-tan") 50%);
 }
+
+// Reset the Discourse core CSS code to avoid scroll issues
+html {
+  overflow-y: initial;
+}

--- a/plugin.rb
+++ b/plugin.rb
@@ -4,7 +4,8 @@
 # authors: Debt Collective team
 
 register_asset 'stylesheets/main.scss'
-
 register_asset 'stylesheets/mobile/main.scss', :mobile
+
+register_asset 'javascripts/helpers/device'
 
 enabled_site_setting :debtcollective_theme_enabled


### PR DESCRIPTION
**What:** Add fixes for signup modal and double scroll issue when modal is open

**Why:** Closes https://github.com/debtcollective/dispute-tools/issues/186

**How:**
What we need to understand is that iOS Safari doesn't support the `overflow: hidden` method to avoid double scroll when a modal is being shown. In that sense to fix the double scroll issue this code adds:
- A way to detect the browser using JS
- Add a extra class to map with CSS and add the fix whenever is needed
- Skip iOS >= 13 and desktop browsers as they doesn't need the fix

Further info about it can be found at: https://css-tricks.com/prevent-page-scrolling-when-a-modal-is-open/

Besides, in order to avoid the cropped modal we need to:
- Overwrite css style from core team that always force the scrollbar
- Use % instead vh units to avoid miss calculation on iOS devices when rendering the modal due to the OS header.

# Screenshots

![http://recordit.co/bIp4XnIr9s](http://recordit.co/bIp4XnIr9s.gif)

_While we don't have content as prelive environment we can make sure is working because when trying to scroll the content behind doesn't get pulled as the video here: https://recordit.co/Uwi1iWIwYh (at the end of the video)_