### PR TITLE
dev: let modal scroll lazy

### DIFF
--- a/assets/stylesheets/_components--modal.scss
+++ b/assets/stylesheets/_components--modal.scss
@@ -11,8 +11,12 @@
   margin-bottom: 0;
 }
 
+.modal-inner-container {
+  -webkit-overflow-scrolling: touch;
+}
+
 // Avoid double scroll on all browsers but Safari iOS <= 12
 body.modal-open {
   height: 100%;
-  overflow: hidden; 
+  overflow: hidden;
 }


### PR DESCRIPTION
**What:** let modal scroll lazy

**Why:** to improve modal scrolling on mobile devices

**How:** adding `-webkit-overflow-scrolling: touch;` to inner modal

https://www.loom.com/share/86580db4a82e45fab6a0538e6fbfcaa9