### PR TITLE
Add categories topic count

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -4,6 +4,7 @@
 
 @import "bootstrap/bootstrap-grid";
 @import "variables";
+@import "functions";
 
 @import "layout";
 @import "type";

--- a/common/common.scss
+++ b/common/common.scss
@@ -1,5 +1,6 @@
-@import url("https://fonts.googleapis.com/css?family=Libre+Franklin:400,600");
+@import url("https://fonts.googleapis.com/css?family=Libre+Franklin:300,400,600");
 @import url("https://s3.amazonaws.com/tds-static/fonts/moregothic/1.0.0/More+Gothic+Bold.css");
+@import url("https://fonts.googleapis.com/icon?family=Material+Icons");
 
 @import "bootstrap/bootstrap-grid";
 @import "variables";

--- a/javascripts/discourse/templates/components/dc-categories-only.hbs
+++ b/javascripts/discourse/templates/components/dc-categories-only.hbs
@@ -6,22 +6,7 @@
     {{#each categories as |c|}}
     {{#if c.is_collective}}
     <div class="dc-col-sm-6">
-      <a class="dc-category dc-card" href={{c.url}} style="border-top-color: #{{c.color}};">
-        <div class="dc-category__content">
-          <h2 class="dc-category__title dc-card__title">
-            {{c.name}}
-          </h2>
-          <div class="dc-category__description dc-card__text dc-clamp-3">
-            {{#if c.description_excerpt}}
-            {{{dir-span c.description_excerpt}}}
-            {{/if}}
-          </div>
-        </div>
-        <div class="dc-category__meta">
-          <span class="material-icons">comment</span>
-          <p class="m-0 ml-1">{{c.totalTopicCount}}</p>
-        </div>
-      </a>
+      {{dc-category-card category=c}}
     </div>
     {{/if}}
     {{/each}}
@@ -35,22 +20,7 @@
     {{#each categories as |c|}}
     {{#unless c.is_collective}}
     <div class="dc-col-sm-6">
-      <a class="dc-category dc-card" href={{c.url}} style="border-top-color: #{{c.color}};">
-        <div class="dc-category__content">
-          <h2 class="dc-category__title dc-card__title">
-            {{c.name}}
-          </h2>
-          <div class="dc-category__description dc-card__text dc-clamp-3">
-            {{#if c.description_excerpt}}
-            {{{dir-span c.description_excerpt}}}
-            {{/if}}
-          </div>
-        </div>
-        <div class="dc-category__meta">
-          <span class="material-icons">comment</span>
-          <p class="m-0 ml-1">{{c.totalTopicCount}}</p>
-        </div>
-      </a>
+      {{dc-category-card category=c}}
     </div>
     {{/unless}}
     {{/each}}

--- a/javascripts/discourse/templates/components/dc-categories-only.hbs
+++ b/javascripts/discourse/templates/components/dc-categories-only.hbs
@@ -7,13 +7,19 @@
     {{#if c.is_collective}}
     <div class="dc-col-sm-6">
       <a class="dc-category dc-card" href={{c.url}} style="border-top-color: #{{c.color}};">
-        <div class="dc-category__title dc-card__title">
-          {{c.name}}
+        <div class="dc-category__content">
+          <h2 class="dc-category__title dc-card__title">
+            {{c.name}}
+          </h2>
+          <div class="dc-category__description dc-card__text">
+            {{#if c.description_excerpt}}
+            {{{dir-span c.description_excerpt}}}
+            {{/if}}
+          </div>
         </div>
-        <div class="dc-category__description dc-card__text">
-          {{#if c.description_excerpt}}
-          {{{dir-span c.description_excerpt}}}
-          {{/if}}
+        <div class="dc-category__meta">
+          <span class="material-icons">comment</span>
+          <p class="m-0 ml-1">{{c.totalTopicCount}}</p>
         </div>
       </a>
     </div>
@@ -30,13 +36,19 @@
     {{#unless c.is_collective}}
     <div class="dc-col-sm-6">
       <a class="dc-category dc-card" href={{c.url}} style="border-top-color: #{{c.color}};">
-        <div class="dc-category__title dc-card__title">
-          {{c.name}}
+        <div class="dc-category__content">
+          <h2 class="dc-category__title dc-card__title">
+            {{c.name}}
+          </h2>
+          <div class="dc-category__description dc-card__text">
+            {{#if c.description_excerpt}}
+            {{{dir-span c.description_excerpt}}}
+            {{/if}}
+          </div>
         </div>
-        <div class="dc-category__description dc-card__text">
-          {{#if c.description_excerpt}}
-          {{{dir-span c.description_excerpt}}}
-          {{/if}}
+        <div class="dc-category__meta">
+          <span class="material-icons">comment</span>
+          <p class="m-0 ml-1">{{c.totalTopicCount}}</p>
         </div>
       </a>
     </div>

--- a/javascripts/discourse/templates/components/dc-categories-only.hbs
+++ b/javascripts/discourse/templates/components/dc-categories-only.hbs
@@ -11,7 +11,7 @@
           <h2 class="dc-category__title dc-card__title">
             {{c.name}}
           </h2>
-          <div class="dc-category__description dc-card__text">
+          <div class="dc-category__description dc-card__text dc-clamp-3">
             {{#if c.description_excerpt}}
             {{{dir-span c.description_excerpt}}}
             {{/if}}
@@ -40,7 +40,7 @@
           <h2 class="dc-category__title dc-card__title">
             {{c.name}}
           </h2>
-          <div class="dc-category__description dc-card__text">
+          <div class="dc-category__description dc-card__text dc-clamp-3">
             {{#if c.description_excerpt}}
             {{{dir-span c.description_excerpt}}}
             {{/if}}

--- a/javascripts/discourse/templates/components/dc-category-card.hbs
+++ b/javascripts/discourse/templates/components/dc-category-card.hbs
@@ -1,0 +1,16 @@
+<a class="dc-category dc-card" href={{category.url}} style="border-top-color: #{{category.color}};">
+  <div class="dc-category__content">
+    <h2 class="dc-category__title dc-card__title">
+      {{category.name}}
+    </h2>
+    <div class="dc-category__description dc-card__text dc-clamp-3">
+      {{#if category.description_excerpt}}
+      {{{dir-span category.description_excerpt}}}
+      {{/if}}
+    </div>
+  </div>
+  <div class="dc-category__meta">
+    <span class="material-icons">comment</span>
+    <p class="m-0 ml-1">{{category.totalTopicCount}}</p>
+  </div>
+</a>

--- a/package.json
+++ b/package.json
@@ -47,7 +47,5 @@
       "pre-commit": "lint-staged"
     }
   },
-  "dependencies": {
-    "material-icons": "^0.3.1"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
       "pre-commit": "lint-staged"
     }
+  },
+  "dependencies": {
+    "material-icons": "^0.3.1"
   }
 }

--- a/scss/card.scss
+++ b/scss/card.scss
@@ -7,14 +7,34 @@
   padding: 1.5rem;
   transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
 
+  // to being able to overwrite #list-area h2 rule
+  #list-area &__title,
   &__title {
     color: $primary;
     text-transform: capitalize;
     font-size: 1.5rem;
     font-weight: 600;
+    margin-top: 0;
   }
 
   &__text {
     color: $primary;
   }
+}
+
+.dc-category {
+  height: 12em;
+  justify-content: space-between;
+}
+
+.dc-category__description {
+  font-weight: 300;
+  font-size: 0.875rem;
+}
+
+.dc-category__meta {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  color: $primary !important;
 }

--- a/scss/functions.scss
+++ b/scss/functions.scss
@@ -1,0 +1,8 @@
+// This solution has strong support on Safari and Chrome which are the main users we have
+@mixin clamp-text($lines: 3) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: $lines;
+}

--- a/scss/layout.scss
+++ b/scss/layout.scss
@@ -1,3 +1,7 @@
 body {
   background: $dc-body-bg;
 }
+
+.dc-clamp-3 {
+  @include clamp-text();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2685,11 +2685,6 @@ markdown-table@^1.1.0:
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.3.tgz#9fcb69bcfdb8717bfd0398c6ec2d93036ef8de60"
   integrity sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==
 
-material-icons@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/material-icons/-/material-icons-0.3.1.tgz#425e06e2448632d6249d6e1ffe2993682c5b171e"
-  integrity sha512-5Hbj76A6xDPcDZEbM4oxTknhWuMwGWnAHVLLPCEq9eVlcHb0fn4koU9ZeyMy1wjARtDEPAHfd5ZdL2Re5hf0zQ==
-
 math-random@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.4.tgz#5dd6943c938548267016d4e34f057583080c514c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2685,6 +2685,11 @@ markdown-table@^1.1.0:
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.3.tgz#9fcb69bcfdb8717bfd0398c6ec2d93036ef8de60"
   integrity sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==
 
+material-icons@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/material-icons/-/material-icons-0.3.1.tgz#425e06e2448632d6249d6e1ffe2993682c5b171e"
+  integrity sha512-5Hbj76A6xDPcDZEbM4oxTknhWuMwGWnAHVLLPCEq9eVlcHb0fn4koU9ZeyMy1wjARtDEPAHfd5ZdL2Re5hf0zQ==
+
 math-random@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.4.tgz#5dd6943c938548267016d4e34f057583080c514c"


### PR DESCRIPTION
**What:** Add categories topic count

**Why:** 
re https://github.com/debtcollective/community/issues/28

**How:** 
Use category model method that is already used by default discourse theme

**Bonus:**
- Create a single file to render the category card
- Add new font weight of 300 to follow designs
- Improve layout and aesthetics of card to follow design

**Screenshots:**
![image](https://user-images.githubusercontent.com/1425162/73682004-c7065400-46bf-11ea-90ce-852efa86241e.png)