### PR TITLE
Category topic list page

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -13,3 +13,5 @@
 
 @import "templates/components/categories-only";
 @import "templates/components/topic-list";
+
+@import "templates/list/topic-author";

--- a/common/common.scss
+++ b/common/common.scss
@@ -11,3 +11,4 @@
 @import "card";
 
 @import "templates/components/categories-only";
+@import "templates/components/topic-list";

--- a/common/common.scss
+++ b/common/common.scss
@@ -9,6 +9,7 @@
 @import "layout";
 @import "type";
 @import "card";
+@import "pill";
 
 @import "templates/components/categories-only";
 @import "templates/components/topic-list";

--- a/javascripts/discourse/initializers/dc-topic-list.js.es6
+++ b/javascripts/discourse/initializers/dc-topic-list.js.es6
@@ -7,6 +7,10 @@ export default {
       api.modifyClass("component:topic-list", {
         tagName: "div"
       });
+
+      api.modifyClass("component:topic-list-item", {
+        tagName: "div"
+      });
     });
   }
 };

--- a/javascripts/discourse/initializers/dc-topic-list.js.es6
+++ b/javascripts/discourse/initializers/dc-topic-list.js.es6
@@ -1,0 +1,12 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+
+export default {
+  name: "dc-topic-list",
+  initialize() {
+    withPluginApi("0.8", api => {
+      api.modifyClass("component:topic-list", {
+        tagName: "div"
+      });
+    });
+  }
+};

--- a/javascripts/discourse/templates/components/dc-category-card.hbs
+++ b/javascripts/discourse/templates/components/dc-category-card.hbs
@@ -1,16 +1,16 @@
 <a class="dc-category dc-card" href={{category.url}} style="border-top-color: #{{category.color}};">
-  <div class="dc-category__content">
-    <h2 class="dc-category__title dc-card__title">
+  <div class="dc-card__content">
+    <h2 class="dc-card__title">
       {{category.name}}
     </h2>
-    <div class="dc-category__description dc-card__text dc-clamp-3">
+    <div class="dc-card__text dc-clamp-3">
       {{#if category.description_excerpt}}
       {{{dir-span category.description_excerpt}}}
       {{/if}}
     </div>
   </div>
-  <div class="dc-category__meta">
+  <div class="dc-card__meta">
     <span class="material-icons">comment</span>
-    <p class="m-0 ml-1">{{category.totalTopicCount}}</p>
+    <p class="m-0 ml-1 dc-text-light">{{category.totalTopicCount}}</p>
   </div>
 </a>

--- a/javascripts/discourse/templates/components/topic-list.hbs
+++ b/javascripts/discourse/templates/components/topic-list.hbs
@@ -1,6 +1,9 @@
 {{!-- https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/components/topic-list.hbs --}}
-{{#each filteredTopics as |topic|}}
-{{topic-list-item topic=topic
+<div class="dc-topic-list-container">
+  <div class="dc-row">
+    {{#each filteredTopics as |topic|}}
+    <div class="dc-col-sm-6">
+      {{topic-list-item topic=topic
                       bulkSelectEnabled=bulkSelectEnabled
                       showTopicPostBadges=showTopicPostBadges
                       hideCategory=hideCategory
@@ -12,5 +15,8 @@
                       lastVisitedTopic=lastVisitedTopic
                       selected=selected
                       tagsForUser=tagsForUser}}
-{{raw "list/visited-line" lastVisitedTopic=lastVisitedTopic topic=topic}}
-{{/each}}
+      {{raw "list/visited-line" lastVisitedTopic=lastVisitedTopic topic=topic}}
+    </div>
+    {{/each}}
+  </div>
+</div>

--- a/javascripts/discourse/templates/components/topic-list.hbs
+++ b/javascripts/discourse/templates/components/topic-list.hbs
@@ -1,0 +1,16 @@
+{{!-- https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/components/topic-list.hbs --}}
+{{#each filteredTopics as |topic|}}
+{{topic-list-item topic=topic
+                      bulkSelectEnabled=bulkSelectEnabled
+                      showTopicPostBadges=showTopicPostBadges
+                      hideCategory=hideCategory
+                      showPosters=showPosters
+                      showLikes=showLikes
+                      showOpLikes=showOpLikes
+                      expandGloballyPinned=expandGloballyPinned
+                      expandAllPinned=expandAllPinned
+                      lastVisitedTopic=lastVisitedTopic
+                      selected=selected
+                      tagsForUser=tagsForUser}}
+{{raw "list/visited-line" lastVisitedTopic=lastVisitedTopic topic=topic}}
+{{/each}}

--- a/javascripts/discourse/templates/list/topic-author.raw.hbs
+++ b/javascripts/discourse/templates/list/topic-author.raw.hbs
@@ -1,0 +1,16 @@
+{{!-- 
+The author is always the first poster, nevertheless, we are not able to use
+helpers like https://handlebarsjs.com/api-reference/data-variables.html#first
+neither change to use handlebars array syntax like "posters.0" because when
+we complete the composition to render the avatar it yields error.
+ --}}
+<div class="dc-show-only-first-poster">
+  {{#each posters as |poster|}}
+  {{avatar 
+    poster 
+    avatarTemplatePath="user.avatar_template" 
+    usernamePath="user.username" 
+    namePath="user.name" 
+    imageSize="large"}}
+  {{/each}}
+</div>

--- a/javascripts/discourse/templates/list/topic-list-item.raw.hbs
+++ b/javascripts/discourse/templates/list/topic-list-item.raw.hbs
@@ -1,25 +1,32 @@
 {{!-- https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/list/topic-list-item.raw.hbs#L1 --}}
 <a class="dc-topic dc-card" href={{topic.lastUnreadUrl}} style="border-top-color: #{{topic.category.color}};">
-  <div class="dc-card__content">
-    <h2 class="dc-card__title">
-      {{topic.fancyTitle}}
-    </h2>
-    <div class="dc-card__meta dc-text-small">
-      {{#if topic.pinned}}
-      <p class="dc-info-pill mr-1" style="background-color: #{{topic.category.color}};">
-        staff post
-      </p>
-      {{/if}}
-      <p class="dc-text-light">
-        {{#if topic.pinned}}&middot;{{/if}} 17 Jan, 2020
-      </p>
+  <header class="dc-card__header">
+    <div class="mr-2">
+      {{raw "list/topic-author" posters=topic.featuredUsers}}
     </div>
+    <div>
+      <h2 class="dc-card__title">
+        {{topic.fancyTitle}}
+      </h2>
+      <div class="dc-card__meta dc-text-small">
+        {{#if topic.pinned}}
+        <p class="dc-info-pill mr-1" style="background-color: #{{topic.category.color}};">
+          staff post
+        </p>
+        {{/if}}
+        <p class="dc-text-light">
+          {{#if topic.pinned}}&middot;{{/if}} 17 Jan, 2020
+        </p>
+      </div>
+    </div>
+  </header>
+  <div class="dc-card__content">
     <div class="dc-card__text dc-clamp-3">
       {{raw "list/topic-excerpt" topic=topic}}
     </div>
   </div>
-  <div class="dc-card__meta">
+  <footer class="dc-card__meta">
     <span class="material-icons">comment</span>
     <p class="m-0 ml-1 dc-text-light">{{topic.replyCount}}</p>
-  </div>
+  </footer>
 </a>

--- a/javascripts/discourse/templates/list/topic-list-item.raw.hbs
+++ b/javascripts/discourse/templates/list/topic-list-item.raw.hbs
@@ -1,0 +1,71 @@
+{{!-- https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/list/topic-list-item.raw.hbs#L1 --}}
+{{#if bulkSelectEnabled}}
+<td class="bulk-select">
+  <input type="checkbox" class="bulk-select">
+</td>
+{{/if}}
+
+{{!--
+  The `~` syntax strip spaces between the elements, making it produce
+  `<a class=topic-post-badges>Some text</a><span class=topic-post-badges>`,
+  with no space between them.
+  This causes the topic-post-badge to be considered the same word as "text"
+  at the end of the link, preventing it from line wrapping onto its own line.
+--}}
+<td class='main-link clearfix' colspan="1">
+  <span class='link-top-line'>
+    {{~raw-plugin-outlet name="topic-list-before-status"}}
+    {{~raw "topic-status" topic=topic}}
+    {{~topic-link topic class="raw-link raw-topic-link"}}
+    {{~#if topic.featured_link}}
+    {{~topic-featured-link topic}}
+    {{~/if}}
+    {{~raw-plugin-outlet name="topic-list-after-title"}}
+    {{~raw "list/unread-indicator" includeUnreadIndicator=includeUnreadIndicator 
+                                   topicId=topic.id 
+                                   unreadClass=unreadClass~}}
+    {{~#if showTopicPostBadges}}
+    {{~raw "topic-post-badges" unread=topic.unread newPosts=topic.displayNewPosts unseen=topic.unseen url=topic.lastUnreadUrl newDotText=newDotText}}
+    {{~/if}}
+  </span>
+  <div class="link-bottom-line">
+    {{#unless hideCategory}}
+    {{#unless topic.isPinnedUncategorized}}
+    {{category-link topic.category}}
+    {{/unless}}
+    {{/unless}}
+    {{discourse-tags topic mode="list" tagsForUser=tagsForUser}}
+    {{raw "list/action-list" topic=topic postNumbers=topic.liked_post_numbers className="likes" icon="heart"}}
+  </div>
+  {{#if expandPinned}}
+  {{raw "list/topic-excerpt" topic=topic}}
+  {{/if}}
+</td>
+
+{{#if showPosters}}
+{{raw "list/posters-column" posters=topic.featuredUsers}}
+{{/if}}
+
+{{raw "list/posts-count-column" topic=topic}}
+
+{{#if showLikes}}
+<td class="num likes">
+  {{#if hasLikes}}
+  <a href='{{topic.summaryUrl}}'>
+    {{number topic.like_count}} {{d-icon "heart"}}</td>
+</a>
+{{/if}}
+{{/if}}
+
+{{#if showOpLikes}}
+<td class="num likes">
+  {{#if hasOpLikes}}
+  <a href='{{topic.summaryUrl}}'>
+    {{number topic.op_like_count}} {{d-icon "heart"}}</td>
+</a>
+{{/if}}
+{{/if}}
+
+<td class="num views {{topic.viewsHeat}}">{{number topic.views numberKey="views_long"}}</td>
+
+{{raw "list/activity-column" topic=topic class="num" tagName="td"}}

--- a/javascripts/discourse/templates/list/topic-list-item.raw.hbs
+++ b/javascripts/discourse/templates/list/topic-list-item.raw.hbs
@@ -1,71 +1,15 @@
 {{!-- https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/list/topic-list-item.raw.hbs#L1 --}}
-{{#if bulkSelectEnabled}}
-<td class="bulk-select">
-  <input type="checkbox" class="bulk-select">
-</td>
-{{/if}}
-
-{{!--
-  The `~` syntax strip spaces between the elements, making it produce
-  `<a class=topic-post-badges>Some text</a><span class=topic-post-badges>`,
-  with no space between them.
-  This causes the topic-post-badge to be considered the same word as "text"
-  at the end of the link, preventing it from line wrapping onto its own line.
---}}
-<td class='main-link clearfix' colspan="1">
-  <span class='link-top-line'>
-    {{~raw-plugin-outlet name="topic-list-before-status"}}
-    {{~raw "topic-status" topic=topic}}
-    {{~topic-link topic class="raw-link raw-topic-link"}}
-    {{~#if topic.featured_link}}
-    {{~topic-featured-link topic}}
-    {{~/if}}
-    {{~raw-plugin-outlet name="topic-list-after-title"}}
-    {{~raw "list/unread-indicator" includeUnreadIndicator=includeUnreadIndicator 
-                                   topicId=topic.id 
-                                   unreadClass=unreadClass~}}
-    {{~#if showTopicPostBadges}}
-    {{~raw "topic-post-badges" unread=topic.unread newPosts=topic.displayNewPosts unseen=topic.unseen url=topic.lastUnreadUrl newDotText=newDotText}}
-    {{~/if}}
-  </span>
-  <div class="link-bottom-line">
-    {{#unless hideCategory}}
-    {{#unless topic.isPinnedUncategorized}}
-    {{category-link topic.category}}
-    {{/unless}}
-    {{/unless}}
-    {{discourse-tags topic mode="list" tagsForUser=tagsForUser}}
-    {{raw "list/action-list" topic=topic postNumbers=topic.liked_post_numbers className="likes" icon="heart"}}
+<a class="dc-topic dc-card" href={{topic.lastUnreadUrl}} style="border-top-color: #{{topic.category.color}};">
+  <div class="dc-card__content">
+    <h2 class="dc-card__title">
+      {{topic.fancyTitle}}
+    </h2>
+    <div class="dc-card__text dc-clamp-3">
+      {{raw "list/topic-excerpt" topic=topic}}
+    </div>
   </div>
-  {{#if expandPinned}}
-  {{raw "list/topic-excerpt" topic=topic}}
-  {{/if}}
-</td>
-
-{{#if showPosters}}
-{{raw "list/posters-column" posters=topic.featuredUsers}}
-{{/if}}
-
-{{raw "list/posts-count-column" topic=topic}}
-
-{{#if showLikes}}
-<td class="num likes">
-  {{#if hasLikes}}
-  <a href='{{topic.summaryUrl}}'>
-    {{number topic.like_count}} {{d-icon "heart"}}</td>
+  <div class="dc-card__meta">
+    <span class="material-icons">comment</span>
+    <p class="m-0 ml-1 dc-text-light">{{topic.replyCount}}</p>
+  </div>
 </a>
-{{/if}}
-{{/if}}
-
-{{#if showOpLikes}}
-<td class="num likes">
-  {{#if hasOpLikes}}
-  <a href='{{topic.summaryUrl}}'>
-    {{number topic.op_like_count}} {{d-icon "heart"}}</td>
-</a>
-{{/if}}
-{{/if}}
-
-<td class="num views {{topic.viewsHeat}}">{{number topic.views numberKey="views_long"}}</td>
-
-{{raw "list/activity-column" topic=topic class="num" tagName="td"}}

--- a/javascripts/discourse/templates/list/topic-list-item.raw.hbs
+++ b/javascripts/discourse/templates/list/topic-list-item.raw.hbs
@@ -4,6 +4,16 @@
     <h2 class="dc-card__title">
       {{topic.fancyTitle}}
     </h2>
+    <div class="dc-card__meta dc-text-small">
+      {{#if topic.pinned}}
+      <p class="dc-info-pill mr-1" style="background-color: #{{topic.category.color}};">
+        staff post
+      </p>
+      {{/if}}
+      <p class="dc-text-light">
+        {{#if topic.pinned}}&middot;{{/if}} 17 Jan, 2020
+      </p>
+    </div>
     <div class="dc-card__text dc-clamp-3">
       {{raw "list/topic-excerpt" topic=topic}}
     </div>

--- a/scss/card.scss
+++ b/scss/card.scss
@@ -7,7 +7,8 @@
   justify-content: space-between;
   flex-direction: column;
   margin-bottom: 1.5rem;
-  padding: 1rem;
+  padding: 1rem 0;
+  @include make-container;
 
   &,
   &:visited,

--- a/scss/card.scss
+++ b/scss/card.scss
@@ -2,6 +2,8 @@
   background: #fbfbfb;
   box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.25);
   display: flex;
+  height: $dc-card-height;
+  justify-content: space-between;
   flex-direction: column;
   margin-bottom: 1.5rem;
   padding: 1.5rem;
@@ -12,29 +14,19 @@
   &__title {
     color: $primary;
     text-transform: capitalize;
-    font-size: 1.5rem;
+    font-size: $dc-font-size-lg;
     font-weight: 600;
     margin-top: 0;
   }
 
   &__text {
+    @include dc-text-light($dc-font-size-sm);
+  }
+
+  &__meta {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
     color: $primary;
   }
-}
-
-.dc-category {
-  height: 12em;
-  justify-content: space-between;
-}
-
-.dc-category__description {
-  font-weight: 300;
-  font-size: 0.875rem;
-}
-
-.dc-category__meta {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  color: $primary !important;
 }

--- a/scss/card.scss
+++ b/scss/card.scss
@@ -10,6 +10,12 @@
   padding: 1.5rem;
   transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
 
+  &,
+  &:visited,
+  &:active {
+    color: $primary;
+  }
+
   // to being able to overwrite #list-area h2 rule
   #list-area &__title,
   &__title {
@@ -28,6 +34,5 @@
     display: flex;
     align-items: center;
     justify-content: flex-start;
-    color: $primary;
   }
 }

--- a/scss/card.scss
+++ b/scss/card.scss
@@ -1,6 +1,7 @@
 .dc-card {
   background: #fbfbfb;
   box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.25);
+  border-top: 0.25rem solid transparent;
   display: flex;
   height: $dc-card-height;
   justify-content: space-between;

--- a/scss/card.scss
+++ b/scss/card.scss
@@ -24,6 +24,11 @@
     font-size: $dc-font-size-lg;
     font-weight: 600;
     margin-top: 0;
+    margin-bottom: 0.625rem;
+  }
+
+  &__title ~ &__meta {
+    margin-top: -0.625rem;
   }
 
   &__text {
@@ -34,5 +39,9 @@
     display: flex;
     align-items: center;
     justify-content: flex-start;
+
+    p {
+      margin: 0;
+    }
   }
 }

--- a/scss/card.scss
+++ b/scss/card.scss
@@ -7,13 +7,17 @@
   justify-content: space-between;
   flex-direction: column;
   margin-bottom: 1.5rem;
-  padding: 1.5rem;
-  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+  padding: 1rem;
 
   &,
   &:visited,
   &:active {
     color: $primary;
+  }
+
+  &__header {
+    display: flex;
+    align-items: center;
   }
 
   // to being able to overwrite #list-area h2 rule

--- a/scss/pill.scss
+++ b/scss/pill.scss
@@ -1,0 +1,7 @@
+.dc-info-pill {
+  background: $gray;
+  border-radius: 0.125rem;
+  color: $white;
+  text-transform: uppercase;
+  padding: 0 0.25rem;
+}

--- a/scss/templates/components/categories-only.scss
+++ b/scss/templates/components/categories-only.scss
@@ -1,5 +1,1 @@
-.dc-categories-container {
-  .dc-card {
-    border-top: 0.25rem solid $dc-primary;
-  }
-}
+// All styles only for categories-only template

--- a/scss/templates/components/topic-list.scss
+++ b/scss/templates/components/topic-list.scss
@@ -1,0 +1,6 @@
+// to allow overwrite .topic-list rule
+.topic-list.topic-list {
+  background: none;
+  border-radius: 0px;
+  box-shadow: none;
+}

--- a/scss/templates/list/topic-author.scss
+++ b/scss/templates/list/topic-author.scss
@@ -1,0 +1,6 @@
+// Ideally, we should be able to achieve this effect with handlebars
+.dc-show-only-first-poster {
+  > *:not(:first-child) {
+    display: none;
+  }
+}

--- a/scss/type.scss
+++ b/scss/type.scss
@@ -5,3 +5,13 @@ body {
 .dc-heading {
   font-size: 2rem;
 }
+
+@mixin dc-text-light($size: "inherit") {
+  color: $primary;
+  font-weight: 300;
+  font-size: $size;
+}
+
+.dc-text-light {
+  @include dc-text-light;
+}

--- a/scss/type.scss
+++ b/scss/type.scss
@@ -15,3 +15,7 @@ body {
 .dc-text-light {
   @include dc-text-light;
 }
+
+.dc-text-small {
+  font-size: $dc-font-size-sm;
+}

--- a/scss/type.scss
+++ b/scss/type.scss
@@ -6,7 +6,7 @@ body {
   font-size: 2rem;
 }
 
-@mixin dc-text-light($size: "inherit") {
+@mixin dc-text-light($size: inherit) {
   color: $primary;
   font-weight: 300;
   font-size: $size;

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -12,8 +12,16 @@ $white: #ffffff;
 $dc-font-family-sans-serif: "Libre Franklin", sans-serif;
 $dc-font-family-monospace: "More Gothic Bold", Impact, sans-serif;
 
+$dc-font-size-base: 1rem;
+$dc-font-size-lg: $font-size-base * 1.5;
+$dc-font-size-sm: $font-size-base * 0.875;
+$dc-font-weight-light: 300;
+$dc-font-weight-normal: 400;
+$dc-font-weight-bold: 600;
+
 $dc-body-bg: $beige;
 $dc-primary: $red;
+$dc-card-height: 14rem;
 
 // Foundation customisation
 


### PR DESCRIPTION
**What:** Add initial customisation for the category topic list page

**Why:** 
re https://github.com/debtcollective/community/issues/29

**How:**
- Replace topic-list template 
- Avoid to render table based grid on topic-list and topic-list-item components

**Extras:**
- Unify height of cards on categories and topic list item
- Improve overall card component to be easier to use within different contexts

**Screenshots:**
![image](https://user-images.githubusercontent.com/1425162/73836834-75b9aa00-4810-11ea-9ac4-267c57bdf098.png)
