### PR TITLE
Fix topic list item

### DIFF
--- a/javascripts/discourse/templates/list/topic-list-item.raw.hbs
+++ b/javascripts/discourse/templates/list/topic-list-item.raw.hbs
@@ -20,11 +20,13 @@
       </div>
     </div>
   </header>
+  {{#if topic.hasExcerpt}}
   <div class="dc-card__content">
     <div class="dc-card__text dc-clamp-3">
-      {{raw "list/topic-excerpt" topic=topic}}
+      {{{dir-span topic.escapedExcerpt}}}
     </div>
   </div>
+  {{/if}}
   <footer class="dc-card__meta">
     <span class="material-icons">comment</span>
     <p class="m-0 ml-1 dc-text-light">{{topic.replyCount}}</p>

--- a/scss/card.scss
+++ b/scss/card.scss
@@ -11,6 +11,7 @@
   @include make-container;
 
   &,
+  &:hover,
   &:visited,
   &:active {
     color: $primary;


### PR DESCRIPTION
**What:** Fixes for the customisation of topic list item

**Why:** re https://github.com/debtcollective/community/issues/29

**How:**
- Avoid to render the whole default raw template which cause broken layout check a2f3d0b
- Avoid icons to change colour as link text on hover e219658

**Screenshots:**
![image](https://user-images.githubusercontent.com/1425162/73971033-7b9db100-491e-11ea-957d-64de0a2eec36.png)

![image](https://user-images.githubusercontent.com/1425162/73971052-83f5ec00-491e-11ea-9634-6f93e7664e90.png)
