### PR TITLE
Add "show more" on topic list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 .discourse-site
 HELP
-./bootstrap

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   // Allow to use built-in @ts-check to help the vanilla JS
-  "javascript.validate.enable": true,
+  "javascript.validate.enable": false,
   // Allow the style linting work as expected
   "editor.formatOnSave": true
 }

--- a/common/common.scss
+++ b/common/common.scss
@@ -6,6 +6,8 @@
 @import "bootstrap/bootstrap-grid";
 @import "functions";
 
+@import "common/components/buttons";
+@import "button";
 @import "layout";
 @import "type";
 @import "card";

--- a/common/common.scss
+++ b/common/common.scss
@@ -2,8 +2,8 @@
 @import url("https://s3.amazonaws.com/tds-static/fonts/moregothic/1.0.0/More+Gothic+Bold.css");
 @import url("https://fonts.googleapis.com/icon?family=Material+Icons");
 
-@import "bootstrap/bootstrap-grid";
 @import "variables";
+@import "bootstrap/bootstrap-grid";
 @import "functions";
 
 @import "layout";

--- a/common/common.scss
+++ b/common/common.scss
@@ -6,7 +6,6 @@
 @import "bootstrap/bootstrap-grid";
 @import "functions";
 
-@import "common/components/buttons";
 @import "button";
 @import "layout";
 @import "type";

--- a/common/common.scss
+++ b/common/common.scss
@@ -13,6 +13,7 @@
 
 @import "templates/components/categories-only";
 @import "templates/components/topic-list";
+@import "templates/components/dc-show-more";
 
 @import "templates/list/dc-topic-author";
 @import "templates/list/dc-topic-card";

--- a/javascripts/discourse/components/dc-show-more.js.es6
+++ b/javascripts/discourse/components/dc-show-more.js.es6
@@ -1,0 +1,33 @@
+import Component from "@ember/component";
+import { action } from "@ember/object";
+
+export default Component.extend({
+  tagName: "section",
+  classNames: ["show-more-section"],
+  classNameBindings: ["isExpanded:expanded:collapsed"],
+  isExpanded: false,
+  displayText: "",
+
+  init() {
+    this._super(...arguments);
+    this._updateDisplayText();
+  },
+
+  willUpdate() {
+    this._updateDisplayText();
+  },
+
+  @action
+  toggleExpanded() {
+    this.set("isExpanded", !this.isExpanded);
+  },
+
+  _updateDisplayText() {
+    this.set(
+      "displayText",
+      this.isExpanded
+        ? I18n.t(themePrefix("dc.show_more.expanded"))
+        : I18n.t(themePrefix("dc.show_more.collapsed"))
+    );
+  }
+});

--- a/javascripts/discourse/components/dc-show-more.js.es6
+++ b/javascripts/discourse/components/dc-show-more.js.es6
@@ -6,6 +6,8 @@ export default Component.extend({
   classNames: ["show-more-section"],
   classNameBindings: ["isExpanded:expanded:collapsed"],
   isExpanded: false,
+  collapsable: false,
+  displayButton: true,
   displayText: "",
 
   init() {
@@ -19,6 +21,7 @@ export default Component.extend({
 
   @action
   toggleExpanded() {
+    this.set("displayButton", this.collapsable);
     this.set("isExpanded", !this.isExpanded);
   },
 

--- a/javascripts/discourse/helpers/dc-format-date.js.es6
+++ b/javascripts/discourse/helpers/dc-format-date.js.es6
@@ -1,0 +1,12 @@
+import { registerUnbound } from "discourse-common/lib/helpers";
+import { shortDate } from "discourse/lib/formatter";
+
+/**
+ * Avoid the need of open components and modify models
+ * in order to format the date with Discourse shortDate
+ * function. Examples of usage of this function can be found
+ * at https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/controllers/composer.js.es6#L420
+ */
+registerUnbound("dc-format-date", function(val) {
+  return new Handlebars.SafeString(shortDate(val));
+});

--- a/javascripts/discourse/templates/components/dc-show-more.hbs
+++ b/javascripts/discourse/templates/components/dc-show-more.hbs
@@ -1,0 +1,4 @@
+{{yield}}
+<button class="dc-btn dc-btn-dark dc-btn-block dc-btn-lg" {{on "click" this.toggleExpanded}}>
+  {{displayText}}
+</button>

--- a/javascripts/discourse/templates/components/dc-show-more.hbs
+++ b/javascripts/discourse/templates/components/dc-show-more.hbs
@@ -1,4 +1,4 @@
 {{yield}}
-<button class="dc-btn dc-btn-dark dc-btn-block dc-btn-lg" {{on "click" this.toggleExpanded}}>
+<button class="btn-show-more" {{on "click" this.toggleExpanded}}>
   {{displayText}}
 </button>

--- a/javascripts/discourse/templates/components/dc-show-more.hbs
+++ b/javascripts/discourse/templates/components/dc-show-more.hbs
@@ -1,4 +1,6 @@
 {{yield}}
-<button class="btn-show-more" {{on "click" this.toggleExpanded}}>
-  {{displayText}}
-</button>
+{{#if displayButton}}
+  <button class="btn-show-more" {{on "click" this.toggleExpanded}}>
+    {{displayText}}
+  </button>
+{{/if}}

--- a/javascripts/discourse/templates/components/topic-list.hbs
+++ b/javascripts/discourse/templates/components/topic-list.hbs
@@ -1,22 +1,24 @@
-{{!-- https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/components/topic-list.hbs --}}
+{{! https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/components/topic-list.hbs }}
 <div class="dc-topic-list-container">
   <div class="dc-row">
     {{#each filteredTopics as |topic|}}
-    <div class="dc-col-sm-6">
-      {{topic-list-item topic=topic
-                      bulkSelectEnabled=bulkSelectEnabled
-                      showTopicPostBadges=showTopicPostBadges
-                      hideCategory=hideCategory
-                      showPosters=showPosters
-                      showLikes=showLikes
-                      showOpLikes=showOpLikes
-                      expandGloballyPinned=expandGloballyPinned
-                      expandAllPinned=expandAllPinned
-                      lastVisitedTopic=lastVisitedTopic
-                      selected=selected
-                      tagsForUser=tagsForUser}}
-      {{raw "list/visited-line" lastVisitedTopic=lastVisitedTopic topic=topic}}
-    </div>
+      <div class="dc-col-sm-6">
+        {{topic-list-item
+          topic=topic
+          bulkSelectEnabled=bulkSelectEnabled
+          showTopicPostBadges=showTopicPostBadges
+          hideCategory=hideCategory
+          showPosters=showPosters
+          showLikes=showLikes
+          showOpLikes=showOpLikes
+          expandGloballyPinned=expandGloballyPinned
+          expandAllPinned=expandAllPinned
+          lastVisitedTopic=lastVisitedTopic
+          selected=selected
+          tagsForUser=tagsForUser
+        }}
+        {{raw "list/visited-line" lastVisitedTopic=lastVisitedTopic topic=topic}}
+      </div>
     {{/each}}
   </div>
 </div>

--- a/javascripts/discourse/templates/components/topic-list.hbs
+++ b/javascripts/discourse/templates/components/topic-list.hbs
@@ -1,23 +1,25 @@
 {{! https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/components/topic-list.hbs }}
 <div class="dc-topic-list-container">
-  <div class="dc-row">
-    {{#each filteredTopics as |topic|}}
-      <div class="dc-col-sm-6">
-        {{topic-list-item
-          topic=topic
-          bulkSelectEnabled=bulkSelectEnabled
-          showTopicPostBadges=showTopicPostBadges
-          hideCategory=hideCategory
-          showPosters=showPosters
-          showLikes=showLikes
-          showOpLikes=showOpLikes
-          expandGloballyPinned=expandGloballyPinned
-          expandAllPinned=expandAllPinned
-          lastVisitedTopic=lastVisitedTopic
-          selected=selected
-          tagsForUser=tagsForUser
-        }}
-      </div>
-    {{/each}}
-  </div>
+  {{#dc-show-more}}
+    <div class="dc-row">
+      {{#each filteredTopics as |topic|}}
+        <div class="dc-col-sm-6 show-more-visible-{{topic.pinned}}">
+          {{topic-list-item
+            topic=topic
+            bulkSelectEnabled=bulkSelectEnabled
+            showTopicPostBadges=showTopicPostBadges
+            hideCategory=hideCategory
+            showPosters=showPosters
+            showLikes=showLikes
+            showOpLikes=showOpLikes
+            expandGloballyPinned=expandGloballyPinned
+            expandAllPinned=expandAllPinned
+            lastVisitedTopic=lastVisitedTopic
+            selected=selected
+            tagsForUser=tagsForUser
+          }}
+        </div>
+      {{/each}}
+    </div>
+  {{/dc-show-more}}
 </div>

--- a/javascripts/discourse/templates/components/topic-list.hbs
+++ b/javascripts/discourse/templates/components/topic-list.hbs
@@ -17,7 +17,6 @@
           selected=selected
           tagsForUser=tagsForUser
         }}
-        {{raw "list/visited-line" lastVisitedTopic=lastVisitedTopic topic=topic}}
       </div>
     {{/each}}
   </div>

--- a/javascripts/discourse/templates/list/dc-topic-card.hbr
+++ b/javascripts/discourse/templates/list/dc-topic-card.hbr
@@ -10,24 +10,31 @@
         </h2>
         <div class="dc-card__meta dc-text-small">
           {{#if topic.pinned}}
-          <p class="dc-info-pill mr-1" style="background-color: #{{topic.category.color}};">
-            staff post
-          </p>
+            <p class="dc-info-pill mr-1" style="background-color: #{{topic.category.color}};">
+              staff post
+            </p>
           {{/if}}
           <p class="dc-text-light">
-            {{#if topic.pinned}}&middot;{{/if}} 17 Jan, 2020
+            {{#if topic.pinned}}
+              ·
+            {{/if}}
+            17 Jan, 2020
           </p>
         </div>
       </div>
     </header>
     {{#if topic.hasExcerpt}}
-    <div class="dc-card__text dc-clamp-3">
-      {{{dir-span topic.escapedExcerpt}}}
-    </div>
+      <div class="dc-card__text dc-clamp-3">
+        {{{dir-span topic.escapedExcerpt}}}
+      </div>
     {{/if}}
     <footer class="dc-card__meta">
-      <span class="material-icons">comment</span>
-      <p class="m-0 ml-1 dc-text-light">{{topic.replyCount}}</p>
+      <span class="material-icons">
+        comment
+      </span>
+      <p class="m-0 ml-1 dc-text-light">
+        {{topic.replyCount}}
+      </p>
     </footer>
   </div>
 </a>

--- a/javascripts/discourse/templates/list/dc-topic-card.hbr
+++ b/javascripts/discourse/templates/list/dc-topic-card.hbr
@@ -18,7 +18,7 @@
             {{#if topic.pinned}}
               ·
             {{/if}}
-            17 Jan, 2020
+            {{dc-format-date topic.createdAt}}
           </p>
         </div>
       </div>

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,8 +1,8 @@
 en:
   dc:
     show_more:
-      expanded: "Show less"
-      collapsed: "Show more"
+      expanded: "Show less topics"
+      collapsed: "Show more topics"
     categories:
       collectives: "Our Collectives"
       others: "Others categories"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,5 +1,8 @@
 en:
   dc:
+    show_more:
+      expanded: "show less"
+      collapsed: "show more"
     categories:
       collectives: "Our Collectives"
       others: "Others categories"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,8 +1,8 @@
 en:
   dc:
     show_more:
-      expanded: "show less"
-      collapsed: "show more"
+      expanded: "Show less"
+      collapsed: "Show more"
     categories:
       collectives: "Our Collectives"
       others: "Others categories"

--- a/scss/button.scss
+++ b/scss/button.scss
@@ -1,12 +1,13 @@
-// https://github.com/discourse/discourse/blob/master/app/assets/stylesheets/common/components/buttons.scss
+@import "discourse/button";
 
 .btn-dark {
   @include btn(
-    $text-color: $secondary,
-    $bg-color: lighten($primary, 10%),
-    $icon-color: $secondary,
-    $hover-bg-color: lighten($primary, 20%),
-    $hover-icon-color: $secondary
+    $text-color: $white,
+    $bg-color: $dark,
+    $icon-color: $white,
+    $hover-text-color: $white,
+    $hover-bg-color: lighten($dark, 10%),
+    $hover-icon-color: $white
   );
   border-radius: $border-radius;
 }

--- a/scss/button.scss
+++ b/scss/button.scss
@@ -1,0 +1,27 @@
+// https://github.com/discourse/discourse/blob/master/app/assets/stylesheets/common/components/buttons.scss
+
+.btn-dark {
+  @include btn(
+    $text-color: $secondary,
+    $bg-color: lighten($primary, 10%),
+    $icon-color: $secondary,
+    $hover-bg-color: lighten($primary, 20%),
+    $hover-icon-color: $secondary
+  );
+  border-radius: $border-radius;
+}
+
+.btn-block {
+  display: block;
+  width: 100%;
+
+  // Vertically space out multiple block buttons
+  + .btn-block {
+    margin-top: $btn-block-spacing-y;
+  }
+}
+
+.btn-lg {
+  font-size: $btn-font-size-lg;
+  padding: $btn-padding-y-lg $btn-padding-x-lg;
+}

--- a/scss/card.scss
+++ b/scss/card.scss
@@ -3,7 +3,7 @@
   box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.25);
   border-top: 0.25rem solid transparent;
   display: flex;
-  height: $dc-card-height;
+  height: $card-height;
   justify-content: space-between;
   flex-direction: column;
   margin-bottom: 1.5rem;
@@ -27,7 +27,7 @@
   &__title {
     color: $primary;
     text-transform: capitalize;
-    font-size: $dc-font-size-lg;
+    font-size: $font-size-lg;
     font-weight: 600;
     margin-top: 0;
     margin-bottom: 0.625rem;
@@ -38,7 +38,7 @@
   }
 
   &__text {
-    @include dc-text-light($dc-font-size-sm);
+    @include dc-text-light($font-size-sm);
   }
 
   &__content {

--- a/scss/card.scss
+++ b/scss/card.scss
@@ -14,7 +14,7 @@
   &:hover,
   &:visited,
   &:active {
-    color: $primary;
+    color: $body-color;
   }
 
   &__header {
@@ -25,7 +25,7 @@
   // to being able to overwrite #list-area h2 rule
   #list-area &__title,
   &__title {
-    color: $primary;
+    color: $body-color;
     text-transform: capitalize;
     font-size: $font-size-lg;
     font-weight: 600;

--- a/scss/discourse/button.scss
+++ b/scss/discourse/button.scss
@@ -1,0 +1,65 @@
+// https://github.com/discourse/discourse/blob/master/app/assets/stylesheets/common/components/buttons.scss
+
+@mixin btn(
+  $text-color: $primary,
+  $bg-color: $primary-low,
+  $icon-color: $primary-high,
+  $hover-text-color: $secondary,
+  $hover-bg-color: $primary-medium,
+  $hover-icon-color: $primary-low
+) {
+  display: inline-block;
+  margin: 0;
+  padding: 6px 12px;
+  min-height: 30px;
+  border: none;
+  box-sizing: border-box;
+  font-weight: normal;
+  color: $text-color;
+  background: $bg-color;
+  font-size: $font-0;
+  line-height: $line-height-small;
+  text-align: center;
+  cursor: pointer;
+  transition: all 0.25s;
+  .d-icon {
+    color: $icon-color;
+    margin-right: 0.45em;
+    transition: color 0.25s;
+    line-height: $line-height-medium; // Match button text line-height
+  }
+  &.no-text {
+    .d-icon {
+      margin-right: 0;
+    }
+  }
+  @include hover {
+    background: $hover-bg-color;
+    color: $hover-text-color;
+    .d-icon {
+      color: $hover-icon-color;
+    }
+  }
+  &[href] {
+    color: $text-color;
+  }
+  &:active,
+  &.btn-active {
+    @include linear-gradient(
+      scale-color($bg-color, $lightness: -20%),
+      $bg-color
+    );
+  }
+  &[disabled],
+  &.disabled {
+    opacity: 0.4;
+    &:hover {
+      color: $text-color;
+      background: $bg-color;
+      .d-icon {
+        color: $icon-color;
+      }
+    }
+    cursor: not-allowed;
+  }
+}

--- a/scss/layout.scss
+++ b/scss/layout.scss
@@ -1,5 +1,5 @@
 body {
-  background: $dc-body-bg;
+  background: $body-bg;
 }
 
 .dc-clamp-3 {

--- a/scss/templates/components/dc-show-more.scss
+++ b/scss/templates/components/dc-show-more.scss
@@ -1,0 +1,5 @@
+.show-more-section {
+  &:not(.expanded) .show-more-visible-false {
+    display: none;
+  }
+}

--- a/scss/templates/components/dc-show-more.scss
+++ b/scss/templates/components/dc-show-more.scss
@@ -3,3 +3,11 @@
     display: none;
   }
 }
+
+.btn-show-more {
+  @extend .btn-dark;
+  @extend .btn-block;
+  @extend .btn-lg;
+  font-weight: $font-weight-bold;
+  font-size: 1.25rem;
+}

--- a/scss/type.scss
+++ b/scss/type.scss
@@ -1,5 +1,5 @@
 body {
-  font-family: $dc-font-family-sans-serif;
+  font-family: $font-family-sans-serif;
 }
 
 .dc-heading {
@@ -17,5 +17,5 @@ body {
 }
 
 .dc-text-small {
-  font-size: $dc-font-size-sm;
+  font-size: $font-size-sm;
 }

--- a/scss/type.scss
+++ b/scss/type.scss
@@ -7,7 +7,6 @@ body {
 }
 
 @mixin dc-text-light($size: inherit) {
-  color: $primary;
   font-weight: 300;
   font-size: $size;
 }

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -9,43 +9,38 @@ $yellow: #ffed9c;
 $white: #ffffff;
 
 // Theme
-$dc-font-family-sans-serif: "Libre Franklin", sans-serif;
-$dc-font-family-monospace: "More Gothic Bold", Impact, sans-serif;
+$font-family-sans-serif: "Libre Franklin", sans-serif;
+$font-family-monospace: "More Gothic Bold", Impact, sans-serif;
 
-$dc-font-size-base: 1rem;
-$dc-font-size-lg: $font-size-base * 1.5;
-$dc-font-size-sm: $font-size-base * 0.875;
-$dc-font-weight-light: 300;
-$dc-font-weight-normal: 400;
-$dc-font-weight-bold: 600;
+$font-size-base: 1rem;
+$font-size-lg: 1rem * 1.5;
+$font-size-sm: 1rem * 0.875;
+$font-weight-light: 300;
+$font-weight-normal: 400;
+$font-weight-bold: 600;
 
-$dc-body-bg: $beige;
-$dc-primary: $red;
-$dc-card-height: 14rem;
+$input-btn-padding-y-lg: 0.75rem;
+$input-btn-padding-x-lg: 1.5rem;
 
-// Foundation customisation
-
-$small-width: map-get(
-  $map: $container-max-widths,
-  $key: "md"
-);
-$medium-width: map-get(
-  $map: $container-max-widths,
-  $key: "lg"
-);
-$large-width: map-get(
-  $map: $container-max-widths,
-  $key: "xl"
+$container-max-widths: (
+  sm: 540px,
+  md: 720px,
+  lg: 960px,
+  xl: 1140px
 );
 
-@import "common/foundation/variables";
+$grid-gutter-width: 30px;
+$container-padding-x: $grid-gutter-width / 2;
+
+$body-bg: $beige;
+$primary: $gray;
+$card-height: 14rem;
 
 /*
-  There is a set of variables $small-width: 800px !default; $medium-width: 995px !default;
-  $large-width: 1110px !default; but due to the inability to overwrite them, this patch overwrites
-  the rule we wanted to affect.
+  There is a set of variables on "Foundation": $small-width: 800px !default; $medium-width: 995px !default;
+  $large-width: 1110px !default; but due to the inability to overwrite them, the rule below overwrites
+  the CSS we wanted to affect.
 */
-
 .wrap {
   max-width: map-get($map: $container-max-widths, $key: "xl");
   padding: 0 $grid-gutter-width/2;

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -32,8 +32,18 @@ $container-max-widths: (
 $grid-gutter-width: 30px;
 $container-padding-x: $grid-gutter-width / 2;
 
+$body-color: $gray;
 $body-bg: $beige;
-$primary: $gray;
+
+$primary: $red;
+$secondary: $green;
+$success: #28a745;
+$info: #17a2b8;
+$warning: #ffc107;
+$danger: #dc3545;
+$light: #f8f9fa;
+$dark: #3c3c3c;
+
 $card-height: 14rem;
 
 /*


### PR DESCRIPTION
**What:** 
Add show more functionality

**Why:** 
Closes https://github.com/debtcollective/community/issues/29

**How:**
- https://github.com/debtcollective/discourse-debtcollective-theme/commit/726f3e5fc6e1f6d1f094eb1d4766d9714df0d791 create a component to handle the feature
- https://github.com/debtcollective/discourse-debtcollective-theme/commit/4b01e714bf2d965f86a599cd55729133e4f22c60 include the component on the topic-list

**Media:**

![http://recordit.co/jYpSz991Id](http://recordit.co/jYpSz991Id.gif)

**Extras:**
- Update VSCode to not use ts check
- Remove "last visited" text from being floating alongside the topics 7f06bd6
- Use real date instead hard coded one f5e9a74  9c64c55
- Fix usage of colours and variables to better adopt Bootstrap patterns 91c5cb4 50ce80a