### PR TITLE
Add discourse fix over raw templates

### DIFF
--- a/javascripts/discourse/templates/components/topic-list-item.hbs
+++ b/javascripts/discourse/templates/components/topic-list-item.hbs
@@ -1,6 +1,0 @@
-{{!-- https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/components/topic-list-item.hbs --}}
-{{!-- 
-  Overwrite this file is needed to bypass issue with raw templates 
-  https://meta.discourse.org/t/unable-to-replace-topic-list-item-raw-hbs-topic-list-item-hbr-on-mobile/141395/3?u=duranmla
---}}
-{{raw 'list/dc-topic-card' topic=topic}}

--- a/javascripts/discourse/templates/list/topic-list-item.hbr
+++ b/javascripts/discourse/templates/list/topic-list-item.hbr
@@ -1,7 +1,2 @@
 {{! https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/list/topic-list-item.hbr }}
-{{! 
-  This template doesn't seems to render as expected
-  https://meta.discourse.org/t/unable-to-replace-topic-list-item-raw-hbs-topic-list-item-hbr-on-mobile/141395
-  the customisation of this is happening within javascripts/discourse/templates/components/topic-list-item.hbs
- }}
 {{raw "list/dc-topic-card" topic=topic}}

--- a/javascripts/discourse/templates/list/topic-list-item.hbr
+++ b/javascripts/discourse/templates/list/topic-list-item.hbr
@@ -1,7 +1,7 @@
-{{!-- https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/list/topic-list-item.hbr --}}
-{{!-- 
+{{! https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/list/topic-list-item.hbr }}
+{{! 
   This template doesn't seems to render as expected
   https://meta.discourse.org/t/unable-to-replace-topic-list-item-raw-hbs-topic-list-item-hbr-on-mobile/141395
   the customisation of this is happening within javascripts/discourse/templates/components/topic-list-item.hbs
- --}}
-{{raw 'list/dc-topic-card' topic=topic}}
+ }}
+{{raw "list/dc-topic-card" topic=topic}}

--- a/javascripts/discourse/templates/mobile/list/topic-list-item.hbr
+++ b/javascripts/discourse/templates/mobile/list/topic-list-item.hbr
@@ -1,7 +1,2 @@
 {{! https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/mobile/list/topic-list-item.hbr }}
-{{! 
-  This template doesn't seems to render as expected
-  https://meta.discourse.org/t/unable-to-replace-topic-list-item-raw-hbs-topic-list-item-hbr-on-mobile/141395
-  the customisation of this is happening within javascripts/discourse/templates/components/topic-list-item.hbs
- }}
 {{raw "list/dc-topic-card" topic=topic}}

--- a/javascripts/discourse/templates/mobile/list/topic-list-item.hbr
+++ b/javascripts/discourse/templates/mobile/list/topic-list-item.hbr
@@ -1,7 +1,7 @@
-{{!-- https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/mobile/list/topic-list-item.hbr --}}
-{{!-- 
+{{! https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/mobile/list/topic-list-item.hbr }}
+{{! 
   This template doesn't seems to render as expected
   https://meta.discourse.org/t/unable-to-replace-topic-list-item-raw-hbs-topic-list-item-hbr-on-mobile/141395
   the customisation of this is happening within javascripts/discourse/templates/components/topic-list-item.hbs
- --}}
-{{raw 'list/dc-topic-card' topic=topic}}
+ }}
+{{raw "list/dc-topic-card" topic=topic}}


### PR DESCRIPTION
**What:** 
Apply fix from Discourse team

**Why:** 
Related to patch at 128bd4c

**How:**
The idea of this commit is allow to use the built-in code for topic-list-item component and just modify the raw components. This can now be done after https://github.com/discourse/discourse/commit/c0ccfdb45e4b1350d37bbf7c56d598f7c3011abb
check more about the topic at https://meta.discourse.org/t/unable-to-replace-topic-list-item-raw-hbs-topic-list-item-hbr-on-mobile/141395/8