### PR TITLE
Base to customise topic detail view

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -18,3 +18,13 @@
 
 @import "templates/list/dc-topic-author";
 @import "templates/list/dc-topic-card";
+
+// Re-apply foundation styles with different variables to overwrite rules
+
+// https://github.com/discourse/discourse/blob/master/app/assets/stylesheets/common/foundation/base.scss
+$tertiary: $red;
+$primary: $body-color;
+$secondary: $body-bg;
+$base-font-family: $font-family-sans-serif;
+$base-font-size: $font-size-base;
+@import "common/foundation/base";

--- a/common/common.scss
+++ b/common/common.scss
@@ -15,9 +15,12 @@
 @import "templates/components/categories-only";
 @import "templates/components/topic-list";
 @import "templates/components/dc-show-more";
+@import "templates/topic";
 
 @import "templates/list/dc-topic-author";
 @import "templates/list/dc-topic-card";
+
+@import "widgets/post";
 
 // Re-apply foundation styles with different variables to overwrite rules
 

--- a/javascripts/discourse/initializers/dc-post.js.es6
+++ b/javascripts/discourse/initializers/dc-post.js.es6
@@ -1,0 +1,47 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+import { h } from "virtual-dom";
+
+export default {
+  name: "dc-post",
+  initialize() {
+    withPluginApi("0.8", api => {
+      api.modifyClass("component:scrolling-post-stream", {
+        didInsertElement() {
+          this._super(...arguments);
+
+          const $topicTitle = $("#topic-title");
+          const $topicTitleDestination = $(".embed-topic-title");
+
+          $(window).on("load", function() {
+            $topicTitle.appendTo(".embed-topic-title");
+          });
+        }
+      });
+
+      api.reopenWidget("post-article", {
+        buildClasses(attrs) {
+          const classes = this._super(attrs);
+          classes.push("dc-topic-post");
+
+          if (attrs.firstPost) {
+            classes.push("is-first-post");
+          }
+
+          return classes;
+        }
+      });
+
+      api.reopenWidget("post-meta-data", {
+        html(attrs) {
+          let html = this._super(attrs);
+
+          if (attrs.firstPost) {
+            html.unshift(this.attach("dc-topic-title", attrs));
+          }
+
+          return html;
+        }
+      });
+    });
+  }
+};

--- a/javascripts/discourse/initializers/dc-post.js.es6
+++ b/javascripts/discourse/initializers/dc-post.js.es6
@@ -39,6 +39,28 @@ export default {
         }
       });
 
+      api.reopenWidget("post-avatar", {
+        tagName: "div.dc-col-1.d-none.d-lg-block",
+        settings: {
+          size: "extra_large",
+          displayPosterName: false
+        },
+        html(attrs) {
+          const html = this._super(attrs);
+
+          return h("div.dc-topic-avatar", html);
+        }
+      });
+
+      api.reopenWidget("post-body", {
+        tagName: "div.dc-col",
+        html(attrs) {
+          const html = this._super(attrs);
+
+          return h("div.dc-topic-body", html);
+        }
+      });
+
       api.reopenWidget("post-article", {
         buildClasses(attrs) {
           const classes = this._super(attrs);

--- a/javascripts/discourse/templates/components/topic-category.hbs
+++ b/javascripts/discourse/templates/components/topic-category.hbs
@@ -1,0 +1,12 @@
+{{! https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/components/topic-category.hbs }}
+{{#unless topic.isPrivateMessage}}
+  <a href={{topic.category.url}}>
+    <span class="dc-text-body">
+      <span class="material-icons dc-inline-icons">
+        arrow_back_ios
+      </span>
+      Back to
+    </span>
+    {{topic.category.name}}
+  </a>
+{{/unless}}

--- a/javascripts/discourse/templates/topic.hbs
+++ b/javascripts/discourse/templates/topic.hbs
@@ -1,0 +1,270 @@
+{{! https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/topic.hbs#L78 }}
+{{#discourse-topic multiSelect=multiSelect enteredAt=enteredAt topic=model hasScrolled=hasScrolled}}
+  {{topic-category topic=model class="topic-category"}}
+  {{#if model.postStream.loaded}}
+    {{#if model.postStream.firstPostPresent}}
+      {{#topic-title cancelled=(action "cancelEditingTopic") save=(action "finishedEditingTopic") model=model}}
+        {{#if editingTopic}}
+          <div class="edit-topic-title">
+            {{private-message-glyph isVisible=model.isPrivateMessage}}
+            {{text-field
+              id="edit-title"
+              value=buffered.title
+              maxlength=siteSettings.max_topic_title_length
+              autofocus="true"
+            }}
+            {{#if showCategoryChooser}}
+              {{category-chooser class="small" value=buffered.category_id onChange=(action "topicCategoryChanged")}}
+            {{/if}}
+            {{#if canEditTags}}
+              {{mini-tag-chooser
+                value=buffered.tags
+                onChange=(action "topicTagsChanged")
+                options=(hash filterable=true categoryId=buffered.category_id filterable=true)
+              }}
+            {{/if}}
+            {{plugin-outlet name="edit-topic" args=(hash model=model buffered=buffered)}}
+            <div class="edit-controls">
+              {{d-button action=(action "finishedEditingTopic") class="btn-primary submit-edit" icon="check"}}
+              {{d-button action=(action "cancelEditingTopic") class="btn-default cancel-edit" icon="times"}}
+              {{#if canRemoveTopicFeaturedLink}}
+                <a
+                  href
+                  class="remove-featured-link"
+                  title="{{i18n "composer.remove_featured_link"}}"
+                  {{action "removeFeaturedLink"}}
+                >
+                  {{d-icon "times-circle"}}
+                  {{featuredLinkDomain}}
+                </a>
+              {{/if}}
+            </div>
+          </div>
+        {{else}}
+          <h1 data-topic-id="{{unbound model.id}}">
+            {{#unless model.is_warning}}
+              {{#if siteSettings.enable_personal_messages}}
+                {{private-message-glyph
+                  isVisible=model.isPrivateMessage
+                  href=pmPath
+                  title="topic_statuses.personal_message.title"
+                  ariaLabel="user.messages.inbox"
+                }}
+              {{else}}
+                {{private-message-glyph isVisible=model.isPrivateMessage}}
+              {{/if}}
+            {{/unless}}
+            {{#if model.details.loaded}}
+              {{topic-status topic=model}}
+              <a href="{{unbound model.url}}" class="fancy-title" {{action "jumpTop"}}>
+                {{{model.fancyTitle}}}
+              </a>
+            {{/if}}
+            {{#if model.details.can_edit}}
+              <a href class="edit-topic" title="{{i18n "edit"}}" {{action "editTopic"}}>
+                {{d-icon "pencil-alt"}}
+              </a>
+            {{/if}}
+          </h1>
+        {{/if}}
+      {{/topic-title}}
+    {{/if}}
+    <div class="container posts">
+      <div class="selected-posts {{unless multiSelect "hidden"}}">
+        {{partial "selected-posts"}}
+      </div>
+      <div class="row">
+        <section class="topic-area" id="topic" data-topic-id="{{unbound model.id}}">
+          <div class="posts-wrapper">
+            {{conditional-loading-spinner condition=model.postStream.loadingAbove}}
+            {{plugin-outlet name="topic-above-posts" args=(hash model=model)}}
+            {{#unless model.postStream.loadingFilter}}
+              {{scrolling-post-stream
+                posts=postsToRender
+                canCreatePost=model.details.can_create_post
+                multiSelect=multiSelect
+                selectedPostsCount=selectedPostsCount
+                selectedQuery=selectedQuery
+                gaps=model.postStream.gaps
+                showReadIndicator=model.show_read_indicator
+                showFlags=(action "showPostFlags")
+                editPost=(action "editPost")
+                showHistory=(route-action "showHistory")
+                showLogin=(route-action "showLogin")
+                showRawEmail=(route-action "showRawEmail")
+                deletePost=(action "deletePost")
+                recoverPost=(action "recoverPost")
+                expandHidden=(action "expandHidden")
+                newTopicAction=(action "replyAsNewTopic")
+                toggleBookmark=(action "toggleBookmark")
+                toggleBookmarkWithReminder=(action "toggleBookmarkWithReminder")
+                togglePostType=(action "togglePostType")
+                rebakePost=(action "rebakePost")
+                changePostOwner=(action "changePostOwner")
+                grantBadge=(action "grantBadge")
+                addNotice=(action "addNotice")
+                removeNotice=(action "removeNotice")
+                lockPost=(action "lockPost")
+                unlockPost=(action "unlockPost")
+                unhidePost=(action "unhidePost")
+                replyToPost=(action "replyToPost")
+                toggleWiki=(action "toggleWiki")
+                toggleSummary=(action "toggleSummary")
+                removeAllowedUser=(action "removeAllowedUser")
+                removeAllowedGroup=(action "removeAllowedGroup")
+                topVisibleChanged=(action "topVisibleChanged")
+                currentPostChanged=(action "currentPostChanged")
+                currentPostScrolled=(action "currentPostScrolled")
+                bottomVisibleChanged=(action "bottomVisibleChanged")
+                togglePostSelection=(action "togglePostSelection")
+                selectReplies=(action "selectReplies")
+                selectBelow=(action "selectBelow")
+                fillGapBefore=(action "fillGapBefore")
+                fillGapAfter=(action "fillGapAfter")
+                showInvite=(route-action "showInvite")
+              }}
+            {{/unless}}
+            {{conditional-loading-spinner condition=model.postStream.loadingBelow}}
+          </div>
+          <div id="topic-bottom"></div>
+          {{#conditional-loading-spinner condition=model.postStream.loadingFilter}}
+            {{#if loadedAllPosts}}
+              {{#if model.pending_posts}}
+                <div class="pending-posts">
+                  {{#each model.pending_posts as |pending|}}
+                    <div class="reviewable-item">
+                      <div class="reviewable-meta-data">
+                        <span class="reviewable-type">
+                          {{i18n "review.awaiting_approval"}}
+                        </span>
+                        <span class="created-at">
+                          {{age-with-tooltip pending.created_at}}
+                        </span>
+                      </div>
+                      <div class="post-contents-wrapper">
+                        {{reviewable-created-by user=currentUser tagName=""}}
+                        <div class="post-contents">
+                          {{reviewable-created-by-name user=currentUser tagName=""}}
+                          <div class="post-body">
+                            {{cook-text pending.raw}}
+                          </div>
+                        </div>
+                      </div>
+                      <div class="reviewable-actions">
+                        {{d-button
+                          class="btn-danger"
+                          label="review.delete"
+                          icon="trash-alt"
+                          action=(action "deletePending" pending)
+                        }}
+                      </div>
+                    </div>
+                  {{/each}}
+                </div>
+              {{/if}}
+              {{#if model.queued_posts_count}}
+                <div class="has-pending-posts">
+                  <div>
+                    {{{i18n "review.topic_has_pending" count=model.queued_posts_count}}}
+                  </div>
+                  {{#link-to "review" (query-params topic_id=model.id type="ReviewableQueuedPost" status="pending")}}
+                    {{i18n "review.view_pending"}}
+                  {{/link-to}}
+                </div>
+              {{/if}}
+              {{#if model.private_topic_timer.execute_at}}
+                {{topic-timer-info
+                  topicClosed=model.closed
+                  statusType=model.private_topic_timer.status_type
+                  executeAt=model.private_topic_timer.execute_at
+                  duration=model.private_topic_timer.duration
+                  removeTopicTimer=(action
+                    "removeTopicTimer" model.private_topic_timer.status_type "private_topic_timer"
+                  )
+                }}
+              {{/if}}
+              {{topic-timer-info
+                topicClosed=model.closed
+                statusType=model.topic_timer.status_type
+                executeAt=model.topic_timer.execute_at
+                basedOnLastPost=model.topic_timer.based_on_last_post
+                duration=model.topic_timer.duration
+                categoryId=model.topic_timer.category_id
+                removeTopicTimer=(action "removeTopicTimer" model.topic_timer.status_type "topic_timer")
+              }}
+              {{#if session.showSignupCta}}
+                {{! replace "Log In to Reply" with the infobox }}{{signup-cta}}
+              {{else if currentUser}}
+                {{plugin-outlet name="topic-above-footer-buttons" args=(hash model=model)}}
+                {{topic-footer-buttons
+                  topic=model
+                  toggleMultiSelect=(action "toggleMultiSelect")
+                  deleteTopic=(action "deleteTopic")
+                  recoverTopic=(action "recoverTopic")
+                  toggleClosed=(action "toggleClosed")
+                  toggleArchived=(action "toggleArchived")
+                  toggleVisibility=(action "toggleVisibility")
+                  showTopicStatusUpdate=(route-action "showTopicStatusUpdate")
+                  showFeatureTopic=(route-action "showFeatureTopic")
+                  showChangeTimestamp=(route-action "showChangeTimestamp")
+                  resetBumpDate=(action "resetBumpDate")
+                  convertToPublicTopic=(action "convertToPublicTopic")
+                  convertToPrivateMessage=(action "convertToPrivateMessage")
+                  toggleBookmark=(action "toggleBookmark")
+                  showFlagTopic=(route-action "showFlagTopic")
+                  toggleArchiveMessage=(action "toggleArchiveMessage")
+                  editFirstPost=(action "editFirstPost")
+                  deferTopic=(action "deferTopic")
+                  replyToPost=(action "replyToPost")
+                }}
+              {{else}}
+                <div id="topic-footer-buttons">
+                  {{d-button
+                    icon="reply"
+                    class="btn-primary pull-right"
+                    action=(route-action "showLogin")
+                    label="topic.reply.title"
+                  }}
+                </div>
+              {{/if}}
+            {{/if}}
+          {{/conditional-loading-spinner}}
+        </section>
+      </div>
+    </div>
+  {{else}}
+    <div class="container">
+      {{#conditional-loading-spinner condition=noErrorYet}}
+        {{#if model.errorHtml}}
+          <div class="not-found">
+            {{{model.errorHtml}}}
+          </div>
+        {{else}}
+          <div class="topic-error">
+            <div>
+              {{model.errorMessage}}
+            </div>
+            {{#if model.noRetry}}
+              {{#unless currentUser}}
+                {{d-button action=(route-action "showLogin") class="btn-primary topic-retry" icon="user" label="log_in"
+                }}
+              {{/unless}}
+            {{else}}
+              {{d-button
+                action=(action "retryLoading")
+                class="btn-primary topic-retry"
+                icon="sync"
+                label="errors.buttons.again"
+              }}
+            {{/if}}
+          </div>
+          {{conditional-loading-spinner condition=retrying}}
+        {{/if}}
+      {{/conditional-loading-spinner}}
+    </div>
+  {{/if}}
+  {{share-popup topic=model replyAsNewTopic=(action "replyAsNewTopic")}}
+  {{#if embedQuoteButton}}
+    {{quote-button quoteState=quoteState selectText=(action "selectText")}}
+  {{/if}}
+{{/discourse-topic}}

--- a/javascripts/discourse/templates/topic.hbs
+++ b/javascripts/discourse/templates/topic.hbs
@@ -2,73 +2,6 @@
 {{#discourse-topic multiSelect=multiSelect enteredAt=enteredAt topic=model hasScrolled=hasScrolled}}
   {{topic-category topic=model class="topic-category"}}
   {{#if model.postStream.loaded}}
-    {{#if model.postStream.firstPostPresent}}
-      {{#topic-title cancelled=(action "cancelEditingTopic") save=(action "finishedEditingTopic") model=model}}
-        {{#if editingTopic}}
-          <div class="edit-topic-title">
-            {{private-message-glyph isVisible=model.isPrivateMessage}}
-            {{text-field
-              id="edit-title"
-              value=buffered.title
-              maxlength=siteSettings.max_topic_title_length
-              autofocus="true"
-            }}
-            {{#if showCategoryChooser}}
-              {{category-chooser class="small" value=buffered.category_id onChange=(action "topicCategoryChanged")}}
-            {{/if}}
-            {{#if canEditTags}}
-              {{mini-tag-chooser
-                value=buffered.tags
-                onChange=(action "topicTagsChanged")
-                options=(hash filterable=true categoryId=buffered.category_id filterable=true)
-              }}
-            {{/if}}
-            {{plugin-outlet name="edit-topic" args=(hash model=model buffered=buffered)}}
-            <div class="edit-controls">
-              {{d-button action=(action "finishedEditingTopic") class="btn-primary submit-edit" icon="check"}}
-              {{d-button action=(action "cancelEditingTopic") class="btn-default cancel-edit" icon="times"}}
-              {{#if canRemoveTopicFeaturedLink}}
-                <a
-                  href
-                  class="remove-featured-link"
-                  title="{{i18n "composer.remove_featured_link"}}"
-                  {{action "removeFeaturedLink"}}
-                >
-                  {{d-icon "times-circle"}}
-                  {{featuredLinkDomain}}
-                </a>
-              {{/if}}
-            </div>
-          </div>
-        {{else}}
-          <h1 data-topic-id="{{unbound model.id}}">
-            {{#unless model.is_warning}}
-              {{#if siteSettings.enable_personal_messages}}
-                {{private-message-glyph
-                  isVisible=model.isPrivateMessage
-                  href=pmPath
-                  title="topic_statuses.personal_message.title"
-                  ariaLabel="user.messages.inbox"
-                }}
-              {{else}}
-                {{private-message-glyph isVisible=model.isPrivateMessage}}
-              {{/if}}
-            {{/unless}}
-            {{#if model.details.loaded}}
-              {{topic-status topic=model}}
-              <a href="{{unbound model.url}}" class="fancy-title" {{action "jumpTop"}}>
-                {{{model.fancyTitle}}}
-              </a>
-            {{/if}}
-            {{#if model.details.can_edit}}
-              <a href class="edit-topic" title="{{i18n "edit"}}" {{action "editTopic"}}>
-                {{d-icon "pencil-alt"}}
-              </a>
-            {{/if}}
-          </h1>
-        {{/if}}
-      {{/topic-title}}
-    {{/if}}
     <div class="container posts">
       <div class="selected-posts {{unless multiSelect "hidden"}}">
         {{partial "selected-posts"}}
@@ -80,6 +13,7 @@
             {{plugin-outlet name="topic-above-posts" args=(hash model=model)}}
             {{#unless model.postStream.loadingFilter}}
               {{scrolling-post-stream
+                topicData=model
                 posts=postsToRender
                 canCreatePost=model.details.can_create_post
                 multiSelect=multiSelect

--- a/javascripts/discourse/widgets/dc-topic-title.js.es6
+++ b/javascripts/discourse/widgets/dc-topic-title.js.es6
@@ -5,6 +5,6 @@ export default createWidget("dc-topic-title", {
   tagName: "div.dc-topic-title",
 
   html(attrs, state) {
-    return h("div.embed-topic-title", "");
+    return h("h1.fancy-title", attrs.fancyTitle);
   }
 });

--- a/javascripts/discourse/widgets/dc-topic-title.js.es6
+++ b/javascripts/discourse/widgets/dc-topic-title.js.es6
@@ -1,0 +1,10 @@
+import { createWidget } from "discourse/widgets/widget";
+import { h } from "virtual-dom";
+
+export default createWidget("dc-topic-title", {
+  tagName: "div.dc-topic-title",
+
+  html(attrs, state) {
+    return h("div.embed-topic-title", "");
+  }
+});

--- a/scss/layout.scss
+++ b/scss/layout.scss
@@ -1,5 +1,6 @@
 body {
-  background: $body-bg;
+  // Usage of variables yield error on SCSS compiler
+  background: linear-gradient(180deg, #dbf8ff 0%, #fcfbf7 88.74%);
 }
 
 .dc-clamp-3 {

--- a/scss/templates/topic.scss
+++ b/scss/templates/topic.scss
@@ -1,0 +1,1 @@
+// styles for topic page

--- a/scss/templates/topic.scss
+++ b/scss/templates/topic.scss
@@ -1,1 +1,7 @@
-// styles for topic page
+.container.posts {
+  margin-top: $spacer;
+}
+
+.small-action.onscreen-post {
+  max-width: 100%;
+}

--- a/scss/type.scss
+++ b/scss/type.scss
@@ -11,10 +11,22 @@ body {
   font-size: $size;
 }
 
+.dc-text-body {
+  font-size: $font-size-base;
+  color: $body-color;
+}
+
 .dc-text-light {
   @include dc-text-light;
 }
 
 .dc-text-small {
   font-size: $font-size-sm;
+}
+
+.dc-inline-icons {
+  $icon-correction: 2px;
+  font-size: $font-size-base;
+  position: relative;
+  top: $icon-correction;
 }

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -33,7 +33,7 @@ $grid-gutter-width: 30px;
 $container-padding-x: $grid-gutter-width / 2;
 
 $body-color: $gray;
-$body-bg: $beige;
+$body-bg: $blue;
 
 $primary: $red;
 $secondary: $green;

--- a/scss/widgets/post.scss
+++ b/scss/widgets/post.scss
@@ -1,0 +1,25 @@
+.dc-topic-post {
+  background-color: $beige;
+  box-shadow: 0 0.125rem 0.125rem rgba(0, 0, 0, 0.25);
+
+  .row > * {
+    border: none;
+  }
+
+  &.is-first-post .topic-meta-data {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: flex-start;
+
+    > * {
+      width: 100%;
+    }
+  }
+
+  // overcome discourse rule
+  #topic-title {
+    margin: 0;
+    padding: 0;
+  }
+}

--- a/scss/widgets/post.scss
+++ b/scss/widgets/post.scss
@@ -1,9 +1,43 @@
+.dc-topic-avatar {
+  text-align: center;
+}
+
+.dc-topic-body {
+  position: relative;
+
+  .post-infos {
+    position: absolute;
+    top: 0;
+    right: 0;
+  }
+
+  .regular.contents {
+    width: 100%;
+
+    .cooked {
+      @include media-breakpoint-up(lg) {
+        width: 90%;
+      }
+    }
+  }
+
+  .topic-map {
+    margin-left: 0;
+  }
+}
+
 .dc-topic-post {
+  @include make-container;
   background-color: $beige;
   box-shadow: 0 0.125rem 0.125rem rgba(0, 0, 0, 0.25);
+  padding-top: $spacer * 1.25;
 
-  .row > * {
-    border: none;
+  .row {
+    @include make-row;
+
+    & > * {
+      border: none;
+    }
   }
 
   &.is-first-post .topic-meta-data {
@@ -11,10 +45,10 @@
     flex-direction: column;
     justify-content: flex-start;
     align-items: flex-start;
+  }
 
-    > * {
-      width: 100%;
-    }
+  .topic-meta-data {
+    margin-bottom: $spacer * 1.75;
   }
 
   // overcome discourse rule
@@ -22,4 +56,13 @@
     margin: 0;
     padding: 0;
   }
+
+  .fancy-title {
+    margin: 0 0 ($spacer * 0.5) 0;
+    line-height: 1;
+  }
+}
+
+.topic-post + .topic-post {
+  margin-top: $spacer * 1.5;
 }

--- a/scss/widgets/post.scss
+++ b/scss/widgets/post.scss
@@ -26,7 +26,8 @@
   }
 }
 
-.dc-topic-post {
+// Make extra emphasis to overcome guest styles
+.dc-topic-post.dc-topic-post {
   @include make-container;
   background-color: $beige;
   box-shadow: 0 0.125rem 0.125rem rgba(0, 0, 0, 0.25);
@@ -57,6 +58,7 @@
   }
 
   .topic-meta-data {
+    margin-left: 0;
     margin-bottom: $spacer * 1.75;
   }
 

--- a/scss/widgets/post.scss
+++ b/scss/widgets/post.scss
@@ -40,11 +40,13 @@
     }
   }
 
-  &.is-first-post .topic-meta-data {
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-    align-items: flex-start;
+  &.is-first-post {
+    .topic-meta-data {
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-start;
+      align-items: flex-start;
+    }
   }
 
   &:not(.is-first-post) {

--- a/scss/widgets/post.scss
+++ b/scss/widgets/post.scss
@@ -47,6 +47,13 @@
     align-items: flex-start;
   }
 
+  &:not(.is-first-post) {
+    .dc-topic-avatar img {
+      width: 2.8125rem;
+      height: 2.8125rem;
+    }
+  }
+
   .topic-meta-data {
     margin-bottom: $spacer * 1.75;
   }


### PR DESCRIPTION
**What:**
Add initial customisation of topic page by adding:
- Breadcrumps
- Base to adopt cards as containers for post

**Why:**
re https://github.com/debtcollective/community/issues/30

**Media:**
![image](https://user-images.githubusercontent.com/1425162/74763591-614dc680-5280-11ea-890e-d619510ecf94.png)


**How:**
For the nature of the code on topic page we need to reopen several widgets related to the topic posts, to have a basic understanding of the hierarchy is important to mention that `topic.hbs` works like: 

```
"templates/topic.hbs"
	"components/scrolling-post-stream.js.es6"
		"widgets/post-stream.js.es6"
			"widgets/post.js.es6" -> several widgets for post composition
```

**Extras:**
- Change all links to follow the same color as design _"red"_
- Change body background to be the gradient one in the design