### PR TITLE
Topic detail card actions

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -21,6 +21,7 @@
 @import "templates/list/dc-topic-card";
 
 @import "widgets/post";
+@import "widgets/embedded-posts";
 
 // Re-apply foundation styles with different variables to overwrite rules
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -21,6 +21,7 @@
 @import "templates/list/dc-topic-card";
 
 @import "widgets/post";
+@import "widgets/post-controls";
 @import "widgets/embedded-posts";
 
 // Re-apply foundation styles with different variables to overwrite rules

--- a/javascripts/discourse/initializers/dc-post.js.es6
+++ b/javascripts/discourse/initializers/dc-post.js.es6
@@ -134,12 +134,14 @@ export default {
           }
 
           if (state.repliesBelow.length) {
+            const replies = state.repliesBelow.map(p => {
+              return this.attach("embedded-post", p, {
+                model: this.store.createRecord("post", p)
+              });
+            });
+
             const embeddedPosts = h("section.embedded-posts.bottom", [
-              state.repliesBelow.map(p => {
-                return this.attach("embedded-post", p, {
-                  model: this.store.createRecord("post", p)
-                });
-              }),
+              replies,
               this.attach("button", {
                 title: "post.collapse",
                 icon: "chevron-up",

--- a/javascripts/discourse/initializers/dc-post.js.es6
+++ b/javascripts/discourse/initializers/dc-post.js.es6
@@ -70,6 +70,10 @@ export default {
         }
       });
 
+      api.reopenWidget("embedded-post", {
+        tagName: "div.dc-embedded-post"
+      });
+
       api.reopenWidget("post-article", {
         defaultState() {
           const state = this._super();
@@ -103,8 +107,9 @@ export default {
           html.push(h("div.row", h("div.dc-col", postMenu)));
 
           if (state.repliesBelow.length) {
-            html.push(
-              h("section.embedded-posts.bottom", [
+            const embeddedPosts = h(
+              "section.embedded-posts.bottom.dc-embedded-posts",
+              [
                 state.repliesBelow.map(p => {
                   return this.attach("embedded-post", p, {
                     model: this.store.createRecord("post", p)
@@ -117,7 +122,14 @@ export default {
                   actionParam: "true",
                   className: "btn collapse-up"
                 })
-              ])
+              ]
+            );
+
+            html.push(
+              h(
+                "div.embedded-posts-container",
+                h("div.row", h("div.dc-col", embeddedPosts))
+              )
             );
           }
 

--- a/javascripts/discourse/initializers/dc-post.js.es6
+++ b/javascripts/discourse/initializers/dc-post.js.es6
@@ -55,6 +55,7 @@ export default {
       api.reopenWidget("post-body", {
         tagName: "div.dc-col",
         html(attrs) {
+          attrs.showTopicMap = false;
           const html = this._super(attrs);
 
           return h("div.dc-topic-body", html);

--- a/javascripts/discourse/initializers/dc-post.js.es6
+++ b/javascripts/discourse/initializers/dc-post.js.es6
@@ -104,7 +104,7 @@ export default {
 
           const postMenu = this.attach("post-menu", attrs, extraState);
 
-          html.push(h("div.row", h("div.dc-col", postMenu)));
+          html.push(h("div.row.post-menu-row", h("div.dc-col", postMenu)));
 
           if (state.repliesAbove.length) {
             const replies = state.repliesAbove.map(p => {

--- a/javascripts/discourse/initializers/dc-post.js.es6
+++ b/javascripts/discourse/initializers/dc-post.js.es6
@@ -106,6 +106,33 @@ export default {
 
           html.push(h("div.row", h("div.dc-col", postMenu)));
 
+          if (state.repliesAbove.length) {
+            const replies = state.repliesAbove.map(p => {
+              return this.attach("embedded-post", p, {
+                model: this.store.createRecord("post", p),
+                state: { above: true }
+              });
+            });
+
+            const embeddedPosts = h("section.embedded-posts.top.dc-component", [
+              this.attach("button", {
+                title: "post.collapse",
+                icon: "chevron-down",
+                action: "toggleReplyAbove",
+                actionParam: "true",
+                className: "btn collapse-down"
+              }),
+              replies
+            ]);
+
+            html.unshift(
+              h(
+                "div.embedded-posts-container.above-post-correction",
+                h("div.row", h("div.dc-col", embeddedPosts))
+              )
+            );
+          }
+
           if (state.repliesBelow.length) {
             const embeddedPosts = h("section.embedded-posts.bottom", [
               state.repliesBelow.map(p => {

--- a/javascripts/discourse/initializers/dc-post.js.es6
+++ b/javascripts/discourse/initializers/dc-post.js.es6
@@ -107,23 +107,20 @@ export default {
           html.push(h("div.row", h("div.dc-col", postMenu)));
 
           if (state.repliesBelow.length) {
-            const embeddedPosts = h(
-              "section.embedded-posts.bottom.dc-embedded-posts",
-              [
-                state.repliesBelow.map(p => {
-                  return this.attach("embedded-post", p, {
-                    model: this.store.createRecord("post", p)
-                  });
-                }),
-                this.attach("button", {
-                  title: "post.collapse",
-                  icon: "chevron-up",
-                  action: "toggleRepliesBelow",
-                  actionParam: "true",
-                  className: "btn collapse-up"
-                })
-              ]
-            );
+            const embeddedPosts = h("section.embedded-posts.bottom", [
+              state.repliesBelow.map(p => {
+                return this.attach("embedded-post", p, {
+                  model: this.store.createRecord("post", p)
+                });
+              }),
+              this.attach("button", {
+                title: "post.collapse",
+                icon: "chevron-up",
+                action: "toggleRepliesBelow",
+                actionParam: "true",
+                className: "btn collapse-up"
+              })
+            ]);
 
             html.push(
               h(

--- a/scss/button.scss
+++ b/scss/button.scss
@@ -1,5 +1,21 @@
 @import "discourse/button";
 
+%action-button {
+  @include btn(
+    $text-color: $white,
+    $bg-color: $btn-action-color,
+    $icon-color: $white,
+    $hover-text-color: $white,
+    $hover-bg-color: lighten($btn-action-color, 10%),
+    $hover-icon-color: $white
+  );
+  border-radius: $border-radius;
+}
+
+.btn-action {
+  @extend %action-button;
+}
+
 .btn-dark {
   @include btn(
     $text-color: $white,

--- a/scss/templates/topic.scss
+++ b/scss/templates/topic.scss
@@ -15,3 +15,7 @@
     padding-right: 4rem;
   }
 }
+
+nav.post-controls button.bookmark.bookmarked .d-icon {
+  color: $primary;
+}

--- a/scss/templates/topic.scss
+++ b/scss/templates/topic.scss
@@ -6,3 +6,12 @@
 .small-action.onscreen-post {
   max-width: 100%;
 }
+
+.dc-topic-title {
+  padding-top: 1.5rem;
+
+  @include media-breakpoint-up(md) {
+    padding-top: 0;
+    padding-right: 4rem;
+  }
+}

--- a/scss/templates/topic.scss
+++ b/scss/templates/topic.scss
@@ -1,4 +1,5 @@
-.container.posts {
+.container.posts,
+.topic-category {
   margin-top: $spacer;
 }
 

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -2,7 +2,7 @@
 $beige: #faf9f5;
 $blue: #d8f6ff;
 $gray: #2b2b2b;
-$green: #d6ffb8;
+$green: #2dcbad;
 $purple: #dac4f5;
 $red: #ff4630;
 $yellow: #ffed9c;
@@ -45,6 +45,7 @@ $light: #f8f9fa;
 $dark: #3c3c3c;
 
 $card-height: 14rem;
+$btn-action-color: $secondary;
 
 /*
   There is a set of variables on "Foundation": $small-width: 800px !default; $medium-width: 995px !default;

--- a/scss/widgets/embedded-posts.scss
+++ b/scss/widgets/embedded-posts.scss
@@ -28,7 +28,7 @@
   }
 }
 
-.embedded-posts.dc-embedded-posts {
+.embedded-posts.embedded-posts {
   margin: 0;
   border: 0;
   padding: 0;

--- a/scss/widgets/embedded-posts.scss
+++ b/scss/widgets/embedded-posts.scss
@@ -33,6 +33,18 @@ section.embedded-posts.top.topic-body.offset2:not(.dc-component) {
   }
 }
 
+.embedded-posts.bottom .collapse-up {
+  @include media-breakpoint-down(lg) {
+    transform: translate(-50%, -50%);
+  }
+}
+
+.embedded-posts.top .collapse-down {
+  @include media-breakpoint-down(lg) {
+    transform: translate(-50%, -52%);
+  }
+}
+
 .embedded-posts.embedded-posts {
   border: 0;
   margin: 0;

--- a/scss/widgets/embedded-posts.scss
+++ b/scss/widgets/embedded-posts.scss
@@ -17,7 +17,12 @@
   }
 }
 
-.embedded-posts.bottom {
+section.embedded-posts.top.topic-body.offset2:not(.dc-component) {
+  display: none;
+}
+
+.embedded-posts.bottom,
+.embedded-posts.top {
   .row {
     padding-bottom: 0;
 
@@ -29,9 +34,11 @@
 }
 
 .embedded-posts.embedded-posts {
-  margin: 0;
   border: 0;
+  margin: 0;
+  max-width: 100%;
   padding: 0;
+  width: auto;
 
   .topic-body {
     @include make-col-ready;

--- a/scss/widgets/embedded-posts.scss
+++ b/scss/widgets/embedded-posts.scss
@@ -1,0 +1,45 @@
+.embedded-posts-container {
+  background: #d8d8d8;
+  border: 0.0625rem solid #979797;
+  padding: $spacer;
+  margin: 0 (-$grid-gutter-width / 2);
+}
+
+.dc-embedded-post {
+  @include make-container;
+  padding-top: $spacer;
+  padding-bottom: $spacer;
+  background: #fbfbfb;
+  box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.25);
+
+  & + & {
+    margin-top: $spacer;
+  }
+}
+
+.embedded-posts.bottom {
+  .row {
+    padding-bottom: 0;
+
+    .topic-avatar,
+    .topic-body {
+      border: none;
+    }
+  }
+}
+
+.embedded-posts.dc-embedded-posts {
+  margin: 0;
+  border: 0;
+  padding: 0;
+
+  .topic-body {
+    @include make-col-ready;
+    @include make-col(11);
+    padding-top: 0;
+
+    > * {
+      padding: 0;
+    }
+  }
+}

--- a/scss/widgets/embedded-posts.scss
+++ b/scss/widgets/embedded-posts.scss
@@ -42,7 +42,13 @@ section.embedded-posts.top.topic-body.offset2:not(.dc-component) {
 
   .topic-body {
     @include make-col-ready;
-    @include make-col(11);
+    @include make-col(12);
+
+    @include media-breakpoint-up(lg) {
+      // Avatar pictures are being rendered and take one column
+      @include make-col(11);
+    }
+
     padding-top: 0;
 
     > * {

--- a/scss/widgets/post-controls.scss
+++ b/scss/widgets/post-controls.scss
@@ -1,0 +1,42 @@
+nav.post-controls {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+
+  &.clearfix::after,
+  &.clearfix::before {
+    clear: initial;
+    display: none;
+  }
+
+  .actions,
+  .show-replies {
+    float: none;
+    margin: 0;
+  }
+
+  .actions {
+    display: flex;
+    flex-direction: row;
+    order: 1;
+
+    @include media-breakpoint-up(lg) {
+      @include make-col-offset(1);
+    }
+
+    > .widget-button.reply {
+      @extend %action-button;
+      margin-left: 0;
+      margin-right: $spacer;
+      order: 1;
+    }
+
+    > * {
+      order: 2;
+    }
+  }
+
+  .show-replies {
+    order: 2;
+  }
+}

--- a/scss/widgets/post.scss
+++ b/scss/widgets/post.scss
@@ -77,3 +77,9 @@
 .topic-post + .topic-post {
   margin-top: $spacer * 1.5;
 }
+
+.post-notice {
+  width: 100%;
+  max-width: none;
+  margin-bottom: $spacer;
+}

--- a/scss/widgets/post.scss
+++ b/scss/widgets/post.scss
@@ -83,3 +83,8 @@
   max-width: none;
   margin-bottom: $spacer;
 }
+
+.post-menu-area,
+section.post-menu-area {
+  padding: 0;
+}

--- a/scss/widgets/post.scss
+++ b/scss/widgets/post.scss
@@ -28,10 +28,18 @@
 
 // Make extra emphasis to overcome guest styles
 .dc-topic-post.dc-topic-post {
+  $padding-top: $spacer * 1.25;
   @include make-container;
   background-color: $beige;
   box-shadow: 0 0.125rem 0.125rem rgba(0, 0, 0, 0.25);
   padding-top: $spacer * 1.25;
+
+  // Allow to move above post components to the edge
+  .above-post-correction,
+  .post-notice {
+    position: relative;
+    top: -($spacer * 1.25);
+  }
 
   .row {
     @include make-row;

--- a/scss/widgets/post.scss
+++ b/scss/widgets/post.scss
@@ -97,6 +97,11 @@
   margin-bottom: $spacer;
 }
 
+.post-menu-row {
+  margin-top: $spacer * 3;
+  border-top: 0.0625rem solid $gray-300;
+}
+
 .post-menu-area,
 section.post-menu-area {
   padding: 0;

--- a/scss/widgets/post.scss
+++ b/scss/widgets/post.scss
@@ -5,6 +5,11 @@
 .dc-topic-body {
   position: relative;
 
+  .read-state {
+    top: -($grid-gutter-width / 4);
+    right: -($grid-gutter-width / 4);
+  }
+
   .post-infos {
     position: absolute;
     top: 0;


### PR DESCRIPTION
**What:**
Add support for embedded posts (replies) and adjust markup of post actions to render as design suggest.

**Why:**
re https://github.com/debtcollective/community/issues/30

**How:**
- reopen widgets related to post such as: `post-avatar` `post-body` `post-article` `post-contents` `post-meta-data` aiming to preserve a lot of the built-in code by discourse but also introducing the usage of grid system we handle.

**Media:**
![localhost_3000_t_vestibulum-porttitor_31_4(1440) (1)](https://user-images.githubusercontent.com/1425162/74967015-79f0e480-5418-11ea-8f78-0a29f2ccdfe6.png)

[Extended UI can be check here](https://user-images.githubusercontent.com/1425162/74967034-81b08900-5418-11ea-8031-773f1665ee4a.png)

**Note:** _styles on mobile may need to be yet adjusted a little bit to perhaps show avatars of posters and update few spaces (in another PR)_