### PR TITLE
Suggested topic list

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -11,6 +11,7 @@
 @import "type";
 @import "card";
 @import "pill";
+@import "utils";
 
 @import "templates/components/categories-only";
 @import "templates/components/topic-list";

--- a/javascripts/discourse/components/dc-show-more.js.es6
+++ b/javascripts/discourse/components/dc-show-more.js.es6
@@ -15,6 +15,16 @@ export default Component.extend({
     this._updateDisplayText();
   },
 
+  didInsertElement() {
+    const visibleElementsClass = ".show-more-visible-true";
+    const hasVisibleElements =
+      this.element.querySelectorAll(visibleElementsClass).length > 0;
+
+    if (hasVisibleElements) return;
+
+    this.toggleExpanded();
+  },
+
   willUpdate() {
     this._updateDisplayText();
   },

--- a/javascripts/discourse/templates/components/dc-topic-list-item-small.hbs
+++ b/javascripts/discourse/templates/components/dc-topic-list-item-small.hbs
@@ -1,0 +1,33 @@
+<a class="dc-topic dc-card dc-topic-small" href={{topic.lastUnreadUrl}}>
+  <div class="dc-row">
+    <div class="dc-col">
+      <div class="dc-card__content">
+        {{raw "list/dc-topic-author" posters=topic.featuredUsers}}
+        <h2 class="dc-card__title">
+          {{topic.fancyTitle}}
+        </h2>
+      </div>
+    </div>
+  </div>
+  <div class="dc-row">
+    <footer>
+      <div class="dc-col">
+        <div class="dc-card__meta">
+          <span class="material-icons">
+            comment
+          </span>
+          <p class="m-0 ml-1 dc-text-light">
+            {{topic.replyCount}}
+          </p>
+          {{#if topic.pinned}}
+            <div id="pinned-topic">
+              <p class="dc-info-pill mr-1" style="background-color: #{{topic.category.color}};">
+                staff post
+              </p>
+            </div>
+          {{/if}}
+        </div>
+      </div>
+    </footer>
+  </div>
+</a>

--- a/javascripts/discourse/templates/components/dc-topic-list-item-small.hbs
+++ b/javascripts/discourse/templates/components/dc-topic-list-item-small.hbs
@@ -13,13 +13,21 @@
     <footer>
       <div class="dc-col">
         <div class="dc-card__meta justify-content-between">
-          <div id="icon-based-info" class="d-flex">
-            <div id="replies" class="d-flex">
-              <span class="material-icons">
+          <div class="icons-line">
+            <div id="replies" class="icons-line-item">
+              <span class="material-icons dc-icon">
                 comment
               </span>
-              <p class="m-0 ml-1 dc-text-light">
+              <p class="icons-line-label">
                 {{topic.replyCount}}
+              </p>
+            </div>
+            <div id="likes" class="icons-line-item">
+              <span class="material-icons dc-icon">
+                favorite
+              </span>
+              <p class="icons-line-label">
+                {{topic.like_count}}
               </p>
             </div>
           </div>

--- a/javascripts/discourse/templates/components/dc-topic-list-item-small.hbs
+++ b/javascripts/discourse/templates/components/dc-topic-list-item-small.hbs
@@ -1,9 +1,9 @@
 <a class="dc-topic dc-card dc-topic-small" href={{topic.lastUnreadUrl}}>
-  <div class="dc-row">
+  <div class="dc-row h-100">
     <div class="dc-col">
-      <div class="dc-card__content">
+      <div class="dc-card__content justify-content-around text-center h-100">
         {{raw "list/dc-topic-author" posters=topic.featuredUsers}}
-        <h2 class="dc-card__title">
+        <h2 class="dc-card__title dc-clamp-2-fixed">
           {{topic.fancyTitle}}
         </h2>
       </div>
@@ -12,16 +12,20 @@
   <div class="dc-row">
     <footer>
       <div class="dc-col">
-        <div class="dc-card__meta">
-          <span class="material-icons">
-            comment
-          </span>
-          <p class="m-0 ml-1 dc-text-light">
-            {{topic.replyCount}}
-          </p>
+        <div class="dc-card__meta justify-content-between">
+          <div id="icon-based-info" class="d-flex">
+            <div id="replies" class="d-flex">
+              <span class="material-icons">
+                comment
+              </span>
+              <p class="m-0 ml-1 dc-text-light">
+                {{topic.replyCount}}
+              </p>
+            </div>
+          </div>
           {{#if topic.pinned}}
             <div id="pinned-topic">
-              <p class="dc-info-pill mr-1" style="background-color: #{{topic.category.color}};">
+              <p class="dc-info-pill-sm" style="background-color: #{{topic.category.color}};">
                 staff post
               </p>
             </div>

--- a/javascripts/discourse/templates/components/suggested-topics.hbs
+++ b/javascripts/discourse/templates/components/suggested-topics.hbs
@@ -1,0 +1,14 @@
+{{! https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/components/suggested-topics.hbs#L8 }}
+<h3 class="suggested-topics-title">
+  {{i18n suggestedTitleLabel}}
+</h3>
+<div class="topics">
+  {{#if topic.isPrivateMessage}}
+    {{basic-topic-list hideCategory="true" showPosters="true" topics=topic.suggestedTopics}}
+  {{else}}
+    {{topic-list filteredTopics=topic.suggestedTopics renderCompact=true}}
+  {{/if}}
+</div>
+<h3 class="suggested-topics-message">
+  {{{browseMoreMessage}}}
+</h3>

--- a/javascripts/discourse/templates/components/topic-list.hbs
+++ b/javascripts/discourse/templates/components/topic-list.hbs
@@ -3,22 +3,28 @@
   {{#dc-show-more}}
     <div class="dc-row">
       {{#each filteredTopics as |topic|}}
-        <div class="dc-col-sm-6 show-more-visible-{{topic.pinned}}">
-          {{topic-list-item
-            topic=topic
-            bulkSelectEnabled=bulkSelectEnabled
-            showTopicPostBadges=showTopicPostBadges
-            hideCategory=hideCategory
-            showPosters=showPosters
-            showLikes=showLikes
-            showOpLikes=showOpLikes
-            expandGloballyPinned=expandGloballyPinned
-            expandAllPinned=expandAllPinned
-            lastVisitedTopic=lastVisitedTopic
-            selected=selected
-            tagsForUser=tagsForUser
-          }}
-        </div>
+        {{#if renderCompact}}
+          <div class="dc-col-sm-4">
+            {{dc-topic-list-item-small topic=topic}}
+          </div>
+        {{else}}
+          <div class="dc-col-sm-6 show-more-visible-{{topic.pinned}}">
+            {{topic-list-item
+              topic=topic
+              bulkSelectEnabled=bulkSelectEnabled
+              showTopicPostBadges=showTopicPostBadges
+              hideCategory=hideCategory
+              showPosters=showPosters
+              showLikes=showLikes
+              showOpLikes=showOpLikes
+              expandGloballyPinned=expandGloballyPinned
+              expandAllPinned=expandAllPinned
+              lastVisitedTopic=lastVisitedTopic
+              selected=selected
+              tagsForUser=tagsForUser
+            }}
+          </div>
+        {{/if}}
       {{/each}}
     </div>
   {{/dc-show-more}}

--- a/javascripts/discourse/templates/list/dc-topic-card.hbr
+++ b/javascripts/discourse/templates/list/dc-topic-card.hbr
@@ -1,40 +1,54 @@
 <a class="dc-topic dc-card" href={{topic.lastUnreadUrl}} style="border-top-color: #{{topic.category.color}};">
-  <div class="mr-2">
-    {{raw "list/dc-topic-author" posters=topic.featuredUsers}}
-  </div>
-  <div class="dc-card__content">
-    <header class="dc-card__header">
-      <div>
-        <h2 class="dc-card__title">
-          {{topic.fancyTitle}}
-        </h2>
-        <div class="dc-card__meta dc-text-small">
-          {{#if topic.pinned}}
-            <p class="dc-info-pill mr-1" style="background-color: #{{topic.category.color}};">
-              staff post
-            </p>
+  <div class="dc-row h-100">
+    <div class="dc-col avatar-col">
+      <div class="mr-2">
+        {{raw "list/dc-topic-author" posters=topic.featuredUsers}}
+      </div>
+    </div>
+    <div class="dc-col">
+      <div class="d-flex flex-column justify-content-between h-100">
+        <div class="dc-card__content">
+          <header class="dc-card__header">
+            <div>
+              <h2 class="dc-card__title">
+                {{topic.fancyTitle}}
+              </h2>
+              <div class="dc-card__meta dc-text-small">
+                {{#if topic.pinned}}
+                  <p class="dc-info-pill mr-1" style="background-color: #{{topic.category.color}};">
+                    staff post
+                  </p>
+                {{/if}}
+                <p class="dc-text-light">
+                  {{#if topic.pinned}}
+                    ·
+                  {{/if}}
+                  {{dc-format-date topic.createdAt}}
+                </p>
+              </div>
+            </div>
+          </header>
+          {{#if topic.hasExcerpt}}
+            <div class="dc-card__text dc-clamp-3">
+              {{{dir-span topic.escapedExcerpt}}}
+            </div>
           {{/if}}
-          <p class="dc-text-light">
-            {{#if topic.pinned}}
-              ·
-            {{/if}}
-            {{dc-format-date topic.createdAt}}
-          </p>
+        </div>
+        <div class="dc-row">
+          <footer>
+            <div class="dc-col">
+              <div class="dc-card__meta">
+                <span class="material-icons">
+                  comment
+                </span>
+                <p class="m-0 ml-1 dc-text-light">
+                  {{topic.replyCount}}
+                </p>
+              </div>
+            </div>
+          </footer>
         </div>
       </div>
-    </header>
-    {{#if topic.hasExcerpt}}
-      <div class="dc-card__text dc-clamp-3">
-        {{{dir-span topic.escapedExcerpt}}}
-      </div>
-    {{/if}}
-    <footer class="dc-card__meta">
-      <span class="material-icons">
-        comment
-      </span>
-      <p class="m-0 ml-1 dc-text-light">
-        {{topic.replyCount}}
-      </p>
-    </footer>
+    </div>
   </div>
 </a>

--- a/javascripts/discourse/templates/list/dc-topic-card.hbr
+++ b/javascripts/discourse/templates/list/dc-topic-card.hbr
@@ -35,18 +35,16 @@
           {{/if}}
         </div>
         <div class="dc-row">
-          <footer>
-            <div class="dc-col">
-              <div class="dc-card__meta">
-                <span class="material-icons">
-                  comment
-                </span>
-                <p class="m-0 ml-1 dc-text-light">
-                  {{topic.replyCount}}
-                </p>
-              </div>
+          <div class="dc-col">
+            <div class="dc-card__meta">
+              <span class="material-icons">
+                comment
+              </span>
+              <p class="m-0 ml-1 dc-text-light">
+                {{topic.replyCount}}
+              </p>
             </div>
-          </footer>
+          </div>
         </div>
       </div>
     </div>

--- a/javascripts/discourse/templates/topic.hbs
+++ b/javascripts/discourse/templates/topic.hbs
@@ -201,4 +201,16 @@
   {{#if embedQuoteButton}}
     {{quote-button quoteState=quoteState selectText=(action "selectText")}}
   {{/if}}
+  <div
+    class="{{if model.relatedMessages.length "related-messages-wrapper"}}
+
+      {{if model.suggestedTopics.length "suggested-topics-wrapper"}}"
+  >
+    {{#if model.relatedMessages.length}}
+      {{related-messages topic=model}}
+    {{/if}}
+    {{#if model.suggestedTopics.length}}
+      {{suggested-topics topic=model}}
+    {{/if}}
+  </div>
 {{/discourse-topic}}

--- a/scss/card.scss
+++ b/scss/card.scss
@@ -1,5 +1,5 @@
 .dc-card {
-  background: #fbfbfb;
+  background: $beige;
   box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.25);
   border-top: 0.25rem solid transparent;
   display: flex;

--- a/scss/card.scss
+++ b/scss/card.scss
@@ -1,6 +1,6 @@
 .dc-card {
   background: $beige;
-  box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 0.125rem 0.125rem rgba(0, 0, 0, 0.25);
   border-top: 0.25rem solid transparent;
   display: flex;
   height: $card-height;

--- a/scss/card.scss
+++ b/scss/card.scss
@@ -58,3 +58,20 @@
     }
   }
 }
+
+.icons-line {
+  display: flex;
+
+  &-item {
+    display: flex;
+
+    & + & {
+      margin-left: $spacer/1.5;
+    }
+  }
+
+  .dc-icon + &-label {
+    @extend .dc-text-light;
+    margin: 0 0 0 $spacer/5;
+  }
+}

--- a/scss/card.scss
+++ b/scss/card.scss
@@ -51,6 +51,7 @@
     display: flex;
     align-items: center;
     justify-content: flex-start;
+    flex-direction: row;
 
     p {
       margin: 0;

--- a/scss/functions.scss
+++ b/scss/functions.scss
@@ -1,8 +1,13 @@
 // This solution has strong support on Safari and Chrome which are the main users we have
-@mixin clamp-text($lines: 3) {
+@mixin clamp-text($lines: 3, $fixed-height: false, $line-height: 1.4em) {
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: $lines;
+
+  @if $fixed-height {
+    line-height: $line-height;
+    height: $line-height * $lines;
+  }
 }

--- a/scss/layout.scss
+++ b/scss/layout.scss
@@ -6,3 +6,7 @@ body {
 .dc-clamp-3 {
   @include clamp-text();
 }
+
+.h-100 {
+  height: 100%;
+}

--- a/scss/layout.scss
+++ b/scss/layout.scss
@@ -3,8 +3,14 @@ body {
   background: linear-gradient(180deg, #dbf8ff 0%, #fcfbf7 88.74%);
 }
 
-.dc-clamp-3 {
-  @include clamp-text();
+@for $i from 1 through 3 {
+  .dc-clamp-#{$i} {
+    @include clamp-text($i);
+  }
+
+  .dc-clamp-#{$i}-fixed {
+    @include clamp-text($i, true);
+  }
 }
 
 .h-100 {

--- a/scss/layout.scss
+++ b/scss/layout.scss
@@ -2,21 +2,3 @@ body {
   // Usage of variables yield error on SCSS compiler
   background: linear-gradient(180deg, #dbf8ff 0%, #fcfbf7 88.74%);
 }
-
-@for $i from 1 through 3 {
-  .dc-clamp-#{$i} {
-    @include clamp-text($i);
-  }
-
-  .dc-clamp-#{$i}-fixed {
-    @include clamp-text($i, true);
-  }
-}
-
-.text-center {
-  text-align: center;
-}
-
-.h-100 {
-  height: 100%;
-}

--- a/scss/layout.scss
+++ b/scss/layout.scss
@@ -13,6 +13,10 @@ body {
   }
 }
 
+.text-center {
+  text-align: center;
+}
+
 .h-100 {
   height: 100%;
 }

--- a/scss/pill.scss
+++ b/scss/pill.scss
@@ -1,7 +1,16 @@
-.dc-info-pill {
+%dc-info-pill {
   background: $gray;
   border-radius: 0.125rem;
   color: $white;
   text-transform: uppercase;
   padding: 0 0.25rem;
+}
+
+.dc-info-pill {
+  @extend %dc-info-pill;
+}
+
+.dc-info-pill-sm {
+  @extend %dc-info-pill;
+  font-size: $font-size-xs;
 }

--- a/scss/templates/components/topic-list.scss
+++ b/scss/templates/components/topic-list.scss
@@ -1,6 +1,6 @@
 // to allow overwrite .topic-list rule
 .topic-list.topic-list {
   background: none;
-  border-radius: 0px;
+  border-radius: 0;
   box-shadow: none;
 }

--- a/scss/templates/list/dc-topic-author.scss
+++ b/scss/templates/list/dc-topic-author.scss
@@ -1,5 +1,7 @@
 // Ideally, we should be able to achieve this effect with handlebars
 .dc-show-only-first-poster {
+  text-align: center;
+
   > *:not(:first-child) {
     display: none;
   }

--- a/scss/templates/list/dc-topic-card.scss
+++ b/scss/templates/list/dc-topic-card.scss
@@ -1,4 +1,6 @@
-.dc-topic.dc-card {
-  flex-direction: row;
-  justify-content: flex-start;
+.dc-topic {
+  .avatar-col {
+    max-width: 3.75rem;
+    padding-right: 0;
+  }
 }

--- a/scss/templates/list/dc-topic-card.scss
+++ b/scss/templates/list/dc-topic-card.scss
@@ -7,9 +7,15 @@
 
 .dc-topic-small.dc-card {
   padding-bottom: 0;
+  height: $card-height * 0.75;
+
+  .dc-card__title {
+    font-size: $font-size-base;
+  }
 
   footer {
     border-top: 0.0625rem solid $gray-300;
+    padding: 0.625rem 0;
     width: 100%;
   }
 }

--- a/scss/templates/list/dc-topic-card.scss
+++ b/scss/templates/list/dc-topic-card.scss
@@ -4,3 +4,12 @@
     padding-right: 0;
   }
 }
+
+.dc-topic-small.dc-card {
+  padding-bottom: 0;
+
+  footer {
+    border-top: 0.0625rem solid $gray-300;
+    width: 100%;
+  }
+}

--- a/scss/utils.scss
+++ b/scss/utils.scss
@@ -1,0 +1,17 @@
+@for $i from 1 through 3 {
+  .dc-clamp-#{$i} {
+    @include clamp-text($i);
+  }
+
+  .dc-clamp-#{$i}-fixed {
+    @include clamp-text($i, true);
+  }
+}
+
+.text-center {
+  text-align: center;
+}
+
+.h-100 {
+  height: 100%;
+}

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -1,5 +1,5 @@
 // Colours
-$beige: #faf9f5;
+$beige: #fbfbfb;
 $blue: #d8f6ff;
 $gray: #2b2b2b;
 $green: #2dcbad;

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -15,6 +15,7 @@ $font-family-monospace: "More Gothic Bold", Impact, sans-serif;
 $font-size-base: 1rem;
 $font-size-lg: 1rem * 1.5;
 $font-size-sm: 1rem * 0.875;
+$font-size-xs: 1rem * 0.75;
 $font-weight-light: 300;
 $font-weight-normal: 400;
 $font-weight-bold: 600;

--- a/scss/widgets/embedded-posts.scss
+++ b/scss/widgets/embedded-posts.scss
@@ -9,8 +9,8 @@
   @include make-container;
   padding-top: $spacer;
   padding-bottom: $spacer;
-  background: #fbfbfb;
-  box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.25);
+  background: $beige;
+  box-shadow: 0 0.125rem 0.125rem rgba(0, 0, 0, 0.25);
 
   & + & {
     margin-top: $spacer;


### PR DESCRIPTION
**What:**
Add customisation for suggested topic list

**Why:**
re https://github.com/debtcollective/community/issues/30

**How:**
Replace the https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/components/suggested-topics.hbs template

**Extras:**
- Improve "show-more" component to avoid hide all content when no pinned topics c1c2003
- Refactor of topic-card to use grid system 80e0942

**Media:**
![https://recordit.co/NrrQlcJ3Ig](https://recordit.co/NrrQlcJ3Ig.gif)