### PR TITLE
Topic footer buttons

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -24,6 +24,7 @@
 @import "widgets/post";
 @import "widgets/post-controls";
 @import "widgets/embedded-posts";
+@import "widgets/select-kit";
 
 // Re-apply foundation styles with different variables to overwrite rules
 

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -1,0 +1,3 @@
+.post-menu-row {
+  padding-top: 0.5rem;
+}

--- a/scss/button.scss
+++ b/scss/button.scss
@@ -12,7 +12,14 @@
   border-radius: $border-radius;
 }
 
-.btn-action {
+.btn-default,
+.widget-button {
+  border-radius: $border-radius;
+}
+
+.btn-action,
+.btn-primary,
+.widget-button.reply {
   @extend %action-button;
 }
 

--- a/scss/button.scss
+++ b/scss/button.scss
@@ -9,7 +9,7 @@
     $hover-bg-color: lighten($btn-action-color, 10%),
     $hover-icon-color: $white
   );
-  border-radius: $border-radius;
+  border-radius: 0.625rem;
 }
 
 .btn-default,

--- a/scss/discourse/button.scss
+++ b/scss/discourse/button.scss
@@ -21,7 +21,7 @@
   line-height: $line-height-small;
   text-align: center;
   cursor: pointer;
-  transition: all 0.25s;
+  transition: background 0.25s;
   .d-icon {
     color: $icon-color;
     margin-right: 0.45em;

--- a/scss/templates/topic.scss
+++ b/scss/templates/topic.scss
@@ -17,6 +17,7 @@
   }
 }
 
-nav.post-controls button.bookmark.bookmarked .d-icon {
+nav.post-controls button.bookmark.bookmarked .d-icon,
+#topic-footer-buttons .bookmark.bookmarked .d-icon-bookmark {
   color: $primary;
 }

--- a/scss/templates/topic.scss
+++ b/scss/templates/topic.scss
@@ -3,7 +3,8 @@
   margin-top: $spacer;
 }
 
-.small-action.onscreen-post {
+.small-action.onscreen-post,
+.topic-status-info {
   max-width: 100%;
 }
 

--- a/scss/templates/topic.scss
+++ b/scss/templates/topic.scss
@@ -19,5 +19,30 @@
 
 nav.post-controls button.bookmark.bookmarked .d-icon,
 #topic-footer-buttons .bookmark.bookmarked .d-icon-bookmark {
-  color: $primary;
+  color: $red;
+}
+
+.select-kit.dropdown-select-box .dropdown-select-box-header,
+#topic-footer-buttons .btn {
+  padding: 0.625rem 0.75rem;
+  border-radius: 0.625rem;
+}
+
+#topic-footer-buttons .btn:not(.btn-primary) {
+  background: transparent;
+  border: 0.0625rem solid $blue;
+  font-weight: $font-weight-bold;
+
+  &:hover {
+    background: $blue;
+  }
+
+  &:not(:hover)
+    .d-icon:not(.d-icon-flag):not(.d-icon-bookmark):not(.d-icon-caret-down) {
+    color: $blue;
+  }
+}
+
+#topic-footer-buttons .select-kit .select-kit-header .selected-name .name {
+  font-weight: $font-weight-bold;
 }

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -1,6 +1,6 @@
 // Colours
 $beige: #fbfbfb;
-$blue: #d8f6ff;
+$blue: #03a9f4;
 $gray: #2b2b2b;
 $green: #2dcbad;
 $purple: #dac4f5;
@@ -34,7 +34,7 @@ $grid-gutter-width: 30px;
 $container-padding-x: $grid-gutter-width / 2;
 
 $body-color: $gray;
-$body-bg: $blue;
+$body-bg: #d8f6ff;
 
 $primary: $red;
 $secondary: $green;

--- a/scss/widgets/select-kit.scss
+++ b/scss/widgets/select-kit.scss
@@ -1,0 +1,7 @@
+:root .select-kit.combo-box .combo-box-header,
+:root .select-kit.combo-box .select-kit-header {
+  background: white;
+  border-radius: $border-radius;
+  border: 0.0625rem solid $gray-300;
+  padding: 0.5rem 0.75rem;
+}


### PR DESCRIPTION
**What:**
Add basic customisation to follow design over topic footer buttons

**Why:**
re https://github.com/debtcollective/community/issues/30

**How:**
- Add CSS updates over the buttons on topic footer buttons

**Extras:**
- Add missing space for post-menu on mobile devices
- Avoid transition `all` on buttons
- Incorporate `select-kit` basic customisation for coherent UI

**Media:**
![https://recordit.co/pE5pijxdBw](https://recordit.co/pE5pijxdBw.gif)

[Mobile screenshot](https://user-images.githubusercontent.com/1425162/75347632-725e8f00-58a1-11ea-8f53-5c200dd8cc0a.png)
