### PR TITLE
Add base for custom header

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -17,6 +17,7 @@
 @import "templates/components/topic-list";
 @import "templates/components/dc-show-more";
 @import "templates/topic";
+@import "templates/user";
 
 @import "templates/list/dc-topic-author";
 @import "templates/list/dc-topic-card";

--- a/common/common.scss
+++ b/common/common.scss
@@ -28,6 +28,7 @@
 @import "widgets/embedded-posts";
 @import "widgets/select-kit";
 @import "widgets/topic-timeline";
+@import "widgets/user-menu";
 
 // Re-apply foundation styles with different variables to overwrite rules
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -21,6 +21,7 @@
 @import "templates/list/dc-topic-author";
 @import "templates/list/dc-topic-card";
 
+@import "widgets/header";
 @import "widgets/post";
 @import "widgets/post-controls";
 @import "widgets/embedded-posts";

--- a/javascripts/discourse/initializers/dc-header.js.es6
+++ b/javascripts/discourse/initializers/dc-header.js.es6
@@ -4,6 +4,19 @@ export default {
   name: "dc-header",
   initialize() {
     withPluginApi("0.8", api => {
+      api.reopenWidget("header-notifications", {
+        html(attrs, state) {
+          const html = this._super(attrs, state);
+          const profileImage = html.find(widget => {
+            if (!widget) return;
+
+            return widget.tagName === "IMG";
+          });
+
+          return profileImage;
+        }
+      });
+
       api.reopenWidget("header-icons", {
         html(attrs, state) {
           const html = this._super(attrs, state);

--- a/javascripts/discourse/initializers/dc-header.js.es6
+++ b/javascripts/discourse/initializers/dc-header.js.es6
@@ -20,7 +20,6 @@ export default {
       api.reopenWidget("header-icons", {
         html(attrs, state) {
           const html = this._super(attrs, state);
-          console.log("html", html);
 
           const menuWidgetIndex = html.findIndex(widget => {
             if (!widget) return;
@@ -32,6 +31,7 @@ export default {
             );
           });
 
+          // remove the hamburguer menu
           html.splice(menuWidgetIndex, 1);
 
           return html;

--- a/javascripts/discourse/initializers/dc-header.js.es6
+++ b/javascripts/discourse/initializers/dc-header.js.es6
@@ -1,0 +1,29 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+
+export default {
+  name: "dc-header",
+  initialize() {
+    withPluginApi("0.8", api => {
+      api.reopenWidget("header-icons", {
+        html(attrs, state) {
+          const html = this._super(attrs, state);
+          console.log("html", html);
+
+          const menuWidgetIndex = html.findIndex(widget => {
+            if (!widget) return;
+
+            return (
+              widget.attrs &&
+              widget.attrs.title &&
+              widget.attrs.title.includes("hamburger_menu")
+            );
+          });
+
+          html.splice(menuWidgetIndex, 1);
+
+          return html;
+        }
+      });
+    });
+  }
+};

--- a/javascripts/discourse/initializers/dc-header.js.es6
+++ b/javascripts/discourse/initializers/dc-header.js.es6
@@ -4,6 +4,20 @@ export default {
   name: "dc-header",
   initialize() {
     withPluginApi("0.8", api => {
+      api.modifyClass("component:site-header", {
+        afterRender() {
+          this._super();
+
+          const searchButton = this.element.querySelector("#search-button");
+
+          if ($(searchButton).hasClass("material-icons")) return;
+
+          $(searchButton)
+            .addClass("material-icons")
+            .html("search");
+        }
+      });
+
       api.reopenWidget("header-notifications", {
         html(attrs, state) {
           const html = this._super(attrs, state);

--- a/javascripts/discourse/initializers/dc-header.js.es6
+++ b/javascripts/discourse/initializers/dc-header.js.es6
@@ -51,6 +51,9 @@ export default {
 
           // add notifications icon with count
           const { user } = attrs;
+
+          if (!user) return html;
+
           const unreadNotifications = user.get("unread_notifications");
 
           html.push(

--- a/javascripts/discourse/initializers/dc-header.js.es6
+++ b/javascripts/discourse/initializers/dc-header.js.es6
@@ -19,6 +19,15 @@ export default {
         }
       });
 
+      api.reopenWidget("user-menu", {
+        defaultState() {
+          const state = this._super();
+          return Object.assign({}, state, {
+            currentQuickAccess: "profile"
+          });
+        }
+      });
+
       api.reopenWidget("header-notifications", {
         html(attrs, state) {
           const html = this._super(attrs, state);

--- a/javascripts/discourse/initializers/dc-header.js.es6
+++ b/javascripts/discourse/initializers/dc-header.js.es6
@@ -1,4 +1,5 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
+import { h } from "virtual-dom";
 
 export default {
   name: "dc-header",
@@ -47,6 +48,55 @@ export default {
 
           // remove the hamburguer menu
           html.splice(menuWidgetIndex, 1);
+
+          // add notifications icon with count
+          const { user } = attrs;
+          const unreadNotifications = user.get("unread_notifications");
+
+          html.push(
+            h(
+              "li.header-dropdown-toggle#notifications",
+              h("a", { href: `${user.path}/notifications` }, [
+                h("div.icon.btn-flat.material-icons", "notifications"),
+                unreadNotifications
+                  ? h(
+                      "span.badge-notification.unread-notifications",
+                      {
+                        title: I18n.t(
+                          themePrefix("notifications.tooltip.regular"),
+                          { count: unreadNotifications }
+                        )
+                      },
+                      unreadNotifications
+                    )
+                  : null
+              ])
+            )
+          );
+
+          // add messages icon with count
+          const unreadPMs = user.get("unread_private_messages");
+
+          html.push(
+            h(
+              "li.header-dropdown-toggle#inbox",
+              h("a", { href: `${user.path}/messages` }, [
+                h("div.icon.btn-flat.material-icons", "email"),
+                unreadPMs
+                  ? h(
+                      "span.badge-notification.unread-private-messages",
+                      {
+                        title: I18n.t(
+                          themePrefix("notifications.tooltip.message"),
+                          { count: unreadPMs }
+                        )
+                      },
+                      unreadPMs
+                    )
+                  : null
+              ])
+            )
+          );
 
           return html;
         }

--- a/javascripts/discourse/templates/components/topic-list-item.hbs
+++ b/javascripts/discourse/templates/components/topic-list-item.hbs
@@ -1,6 +1,6 @@
-{{!-- https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/components/topic-list-item.hbs --}}
-{{!-- 
+{{! https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/components/topic-list-item.hbs }}
+{{! 
   Overwrite this file is needed to bypass issue with raw templates 
   https://meta.discourse.org/t/unable-to-replace-topic-list-item-raw-hbs-topic-list-item-hbr-on-mobile/141395/3?u=duranmla
---}}
-{{raw 'list/dc-topic-card' topic=topic}}
+}}
+{{raw "list/dc-topic-card" topic=topic bulkSelectEnabled=bulkSelectEnabled}}

--- a/javascripts/discourse/templates/list/dc-topic-card.hbr
+++ b/javascripts/discourse/templates/list/dc-topic-card.hbr
@@ -1,59 +1,123 @@
-<a
-  class="dc-topic dc-card"
-  href={{topic.lastUnreadUrl}}
-  style="border-top-color: #{{topic.category.color}};"
->
-  <div class="dc-row h-100">
-    <div class="dc-col avatar-col">
-      <div class="mr-2">
-        {{raw "list/dc-topic-author" posters=topic.featuredUsers}}
-      </div>
+{{#if bulkSelectEnabled}}
+  <div
+    class="dc-topic dc-card"
+    style="border-top-color: #{{topic.category.color}};"
+  >
+    <div class="dc-topic-bulk-select">
+      <input type="checkbox" class="bulk-select" />
     </div>
-    <div class="dc-col">
-      <div class="d-flex flex-column justify-content-between h-100">
-        <div class="dc-card__content">
-          <header class="dc-card__header">
-            <div>
-              <h2 class="dc-card__title">
-                {{{topic.fancyTitle}}}
-              </h2>
-              <div class="dc-card__meta dc-text-small">
-                {{#if topic.pinned}}
-                  <p
-                    class="dc-info-pill mr-1"
-                    style="background-color: #{{topic.category.color}};"
-                  >
-                    staff post
-                  </p>
-                {{/if}}
-                <p class="dc-text-light">
+    <div class="dc-row h-100">
+      <div class="dc-col avatar-col">
+        <div class="mr-2">
+          {{raw "list/dc-topic-author" posters=topic.featuredUsers}}
+        </div>
+      </div>
+      <div class="dc-col">
+        <div class="d-flex flex-column justify-content-between h-100">
+          <div class="dc-card__content">
+            <header class="dc-card__header">
+              <div>
+                <h2 class="dc-card__title">
+                  {{{topic.fancyTitle}}}
+                </h2>
+                <div class="dc-card__meta dc-text-small">
                   {{#if topic.pinned}}
-                    ·
+                    <p
+                      class="dc-info-pill mr-1"
+                      style="background-color: #{{topic.category.color}};"
+                    >
+                      staff post
+                    </p>
                   {{/if}}
-                  {{dc-format-date topic.createdAt}}
+                  <p class="dc-text-light">
+                    {{#if topic.pinned}}
+                      ·
+                    {{/if}}
+                    {{dc-format-date topic.createdAt}}
+                  </p>
+                </div>
+              </div>
+            </header>
+            {{#if topic.hasExcerpt}}
+              <div class="dc-card__text dc-clamp-3">
+                {{{dir-span topic.escapedExcerpt}}}
+              </div>
+            {{/if}}
+          </div>
+          <div class="dc-row">
+            <div class="dc-col">
+              <div class="dc-card__meta">
+                <span class="material-icons">
+                  comment
+                </span>
+                <p class="m-0 ml-1 dc-text-light">
+                  {{topic.replyCount}}
                 </p>
               </div>
-            </div>
-          </header>
-          {{#if topic.hasExcerpt}}
-            <div class="dc-card__text dc-clamp-3">
-              {{{dir-span topic.escapedExcerpt}}}
-            </div>
-          {{/if}}
-        </div>
-        <div class="dc-row">
-          <div class="dc-col">
-            <div class="dc-card__meta">
-              <span class="material-icons">
-                comment
-              </span>
-              <p class="m-0 ml-1 dc-text-light">
-                {{topic.replyCount}}
-              </p>
             </div>
           </div>
         </div>
       </div>
     </div>
   </div>
-</a>
+{{else}}
+  <a
+    class="dc-topic dc-card"
+    href={{topic.lastUnreadUrl}}
+    style="border-top-color: #{{topic.category.color}};"
+  >
+    <div class="dc-row h-100">
+      <div class="dc-col avatar-col">
+        <div class="mr-2">
+          {{raw "list/dc-topic-author" posters=topic.featuredUsers}}
+        </div>
+      </div>
+      <div class="dc-col">
+        <div class="d-flex flex-column justify-content-between h-100">
+          <div class="dc-card__content">
+            <header class="dc-card__header">
+              <div>
+                <h2 class="dc-card__title">
+                  {{{topic.fancyTitle}}}
+                </h2>
+                <div class="dc-card__meta dc-text-small">
+                  {{#if topic.pinned}}
+                    <p
+                      class="dc-info-pill mr-1"
+                      style="background-color: #{{topic.category.color}};"
+                    >
+                      staff post
+                    </p>
+                  {{/if}}
+                  <p class="dc-text-light">
+                    {{#if topic.pinned}}
+                      ·
+                    {{/if}}
+                    {{dc-format-date topic.createdAt}}
+                  </p>
+                </div>
+              </div>
+            </header>
+            {{#if topic.hasExcerpt}}
+              <div class="dc-card__text dc-clamp-3">
+                {{{dir-span topic.escapedExcerpt}}}
+              </div>
+            {{/if}}
+          </div>
+          <div class="dc-row">
+            <div class="dc-col">
+              <div class="dc-card__meta">
+                <span class="material-icons">
+                  comment
+                </span>
+                <p class="m-0 ml-1 dc-text-light">
+                  {{topic.replyCount}}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </a>
+{{/if}}

--- a/javascripts/discourse/templates/list/dc-topic-card.hbr
+++ b/javascripts/discourse/templates/list/dc-topic-card.hbr
@@ -1,3 +1,4 @@
+{{! TODO: avoid to duplicate whole code in favor of conditionally change tagName }}
 {{#if bulkSelectEnabled}}
   <div
     class="dc-topic dc-card"

--- a/javascripts/discourse/templates/list/topic-list-item.hbr
+++ b/javascripts/discourse/templates/list/topic-list-item.hbr
@@ -1,7 +1,7 @@
-{{!-- https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/list/topic-list-item.hbr --}}
-{{!-- 
+{{! https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/list/topic-list-item.hbr }}
+{{! 
   This template doesn't seems to render as expected
   https://meta.discourse.org/t/unable-to-replace-topic-list-item-raw-hbs-topic-list-item-hbr-on-mobile/141395
   the customisation of this is happening within javascripts/discourse/templates/components/topic-list-item.hbs
- --}}
-{{raw 'list/dc-topic-card' topic=topic}}
+ }}
+{{raw "list/dc-topic-card" topic=topic bulkSelectEnabled=bulkSelectEnabled}}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -6,3 +6,11 @@ en:
     categories:
       collectives: "Our Collectives"
       others: "Others categories"
+  notifications:
+    tooltip:
+      regular:
+        one: "%{count} unseen notification"
+        other: "{{count}} unseen notifications"
+      message:
+        one: "%{count} unread message"
+        other: "{{count}} unread messages"

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -1,3 +1,19 @@
 .post-menu-row {
   padding-top: 0.5rem;
 }
+
+.menu-links-row {
+  .glyphs {
+    .user-notifications-link,
+    .user-pms-link {
+      display: block;
+    }
+  }
+}
+
+.d-header-icons {
+  #notifications,
+  #inbox {
+    display: none;
+  }
+}

--- a/scss/templates/list/dc-topic-card.scss
+++ b/scss/templates/list/dc-topic-card.scss
@@ -5,6 +5,17 @@
   }
 }
 
+.dc-topic-bulk-select {
+  position: absolute;
+  right: 4px;
+  top: 4px;
+  margin: 0;
+}
+
+.dc-topic.dc-card {
+  position: relative;
+}
+
 .dc-topic-small.dc-card {
   padding-bottom: 0;
   height: $card-height * 0.75;

--- a/scss/templates/user.scss
+++ b/scss/templates/user.scss
@@ -1,0 +1,3 @@
+.user-content {
+  background: transparent;
+}

--- a/scss/templates/user.scss
+++ b/scss/templates/user.scss
@@ -1,3 +1,7 @@
 .user-content {
   background: transparent;
 }
+
+.user-content-wrapper .show-mores {
+  position: relative;
+}

--- a/scss/widgets/header.scss
+++ b/scss/widgets/header.scss
@@ -1,3 +1,8 @@
+.d-header .header-buttons {
+  order: 2;
+  margin: 0 0 0 0.5rem;
+}
+
 .d-header-icons {
   align-items: center;
   display: flex;

--- a/scss/widgets/header.scss
+++ b/scss/widgets/header.scss
@@ -1,6 +1,36 @@
 .d-header-icons {
+  align-items: center;
+  display: flex;
+
+  li {
+    order: 1;
+
+    & + li {
+      margin-left: $spacer/2;
+    }
+  }
+
+  #inbox {
+    order: 2;
+  }
+
+  #notifications {
+    order: 3;
+  }
+
+  #current-user {
+    order: 4;
+  }
+
   .icon.btn-flat.material-icons {
+    font-size: $font-size-base * 1.25;
     color: $dark;
     height: auto;
+    width: auto;
+  }
+
+  .badge-notification {
+    left: -2px;
+    right: auto;
   }
 }

--- a/scss/widgets/header.scss
+++ b/scss/widgets/header.scss
@@ -1,0 +1,6 @@
+.d-header-icons {
+  .icon.btn-flat.material-icons {
+    color: $dark;
+    height: auto;
+  }
+}

--- a/scss/widgets/user-menu.scss
+++ b/scss/widgets/user-menu.scss
@@ -1,0 +1,8 @@
+.menu-links-row {
+  .glyphs {
+    .user-notifications-link,
+    .user-pms-link {
+      display: none;
+    }
+  }
+}


### PR DESCRIPTION
**What:**
Add base for header customisation and button with notifications

**Why:**
re https://github.com/debtcollective/community/issues/27

**How:**
- Reopen several widgets involved within the header creation and SCSS customisation so we hide the icons and show them within the header with their badges of counts.

**Extras:**
- Fix the topic list item to have support for bulk selection _(check video sec 34)_ efa1a4d

**Media:**
https://www.loom.com/share/dca06bcd7c4949ed8886ebbd0bd6f96a
