### PR TITLE
fix(topic): dividers full width and time gaps with top margin

### DIFF
--- a/scss/templates/topic.scss
+++ b/scss/templates/topic.scss
@@ -3,7 +3,11 @@
   margin-top: $spacer;
 }
 
-.small-action.onscreen-post,
+.time-gap.small-action {
+  margin-top: $spacer * 2;
+}
+
+.small-action.small-action,
 .topic-status-info {
   max-width: 100%;
 }


### PR DESCRIPTION
**What:**
- Allow all dividers to set width 100%
- Add margin top to time gaps dividers

**Why:**
re https://app.asana.com/0/1160587988086971/1164497105920009

**Media:**
![image](https://user-images.githubusercontent.com/1425162/76559204-0124fb80-649f-11ea-96c8-d1409c46bdc8.png)
