### PR TITLE
fix(header): move header-buttons to always render first than user-menu

### DIFF
--- a/scss/widgets/header.scss
+++ b/scss/widgets/header.scss
@@ -4,6 +4,14 @@
   margin-bottom: 0;
 }
 
+.d-header .panel {
+  display: flex;
+
+  .d-header-icons {
+    order: 2;
+  }
+}
+
 .d-header .header-buttons {
   order: 2;
   margin: 0 0 0 0.5rem;


### PR DESCRIPTION
**What:**
Make sure header buttons render before user-menu

**Why:**
After seeing the theme preview we spot some differences

**Media:**

**Before:**
![image](https://user-images.githubusercontent.com/1425162/76618868-e64b9900-6529-11ea-980e-1eed5d235a60.png)

**After:**
![image](https://user-images.githubusercontent.com/1425162/76618882-ef3c6a80-6529-11ea-9f35-2d0b1eb243ec.png)


