### PR TITLE
Remove the navigation component from homepage

### DIFF
--- a/scss/templates/components/list-controls.scss
+++ b/scss/templates/components/list-controls.scss
@@ -1,3 +1,15 @@
+body {
+  .list-controls {
+    display: block;
+  }
+
+  &.navigation-categories {
+    .list-controls {
+      display: none;
+    }
+  }
+}
+
 .list-controls {
   .select-kit.categories-admin-dropdown,
   .select-kit.tags-admin-dropdown,


### PR DESCRIPTION
**What:**
Set display none for list-controls within the homepage

**Why:**
Closes https://app.asana.com/0/1159164196409129/1167976328111755/f

**How:**
- Keep a similar approach to #33 that renders the hero only in homepage _(we do the same but to remove only on the homepage)_