### PR TITLE
Fix titles to have a limit of lines to avoid broken layout

### DIFF
--- a/javascripts/discourse/templates/components/dc-category-card.hbs
+++ b/javascripts/discourse/templates/components/dc-category-card.hbs
@@ -4,7 +4,7 @@
   style="border-top-color: #{{category.color}};"
 >
   <div class="dc-card__content">
-    <h2 class="dc-card__title">
+    <h2 class="dc-card__title dc-clamp-3">
       {{category.name}}
     </h2>
     <div class="dc-card__text dc-clamp-3">

--- a/javascripts/discourse/templates/list/dc-topic-card.hbr
+++ b/javascripts/discourse/templates/list/dc-topic-card.hbr
@@ -18,7 +18,7 @@
           <div class="dc-card__content">
             <header class="dc-card__header">
               <div>
-                <h2 class="dc-card__title">
+                <h2 class="dc-card__title dc-clamp-3">
                   {{{topic.fancyTitle}}}
                 </h2>
                 <div class="dc-card__meta dc-text-small">
@@ -78,7 +78,7 @@
           <div class="dc-card__content">
             <header class="dc-card__header">
               <div>
-                <h2 class="dc-card__title">
+                <h2 class="dc-card__title dc-clamp-3">
                   {{{topic.fancyTitle}}}
                 </h2>
                 <div class="dc-card__meta dc-text-small">


### PR DESCRIPTION
**What:**
Add clamp utility within titles for categories and topics

**Why:**
Closes https://app.asana.com/0/1159164196409156/1168068725630295

**How:**
Use our utility class `dc-clamp-N`

**Media:**
- [How it looks before](https://app.asana.com/0/1159164196409156/1168068725630295)
- [How it looks now](https://user-images.githubusercontent.com/1425162/77678636-bcff2400-6f91-11ea-90e4-0f4e67c0153e.png)
