### PR TITLE
Add "latest activity" support

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -25,6 +25,7 @@
 
 @import "templates/list/dc-topic-author";
 @import "templates/list/dc-topic-card";
+@import "templates/list/visited-line";
 
 @import "widgets/header";
 @import "widgets/post";

--- a/javascripts/discourse/templates/components/topic-list.hbs
+++ b/javascripts/discourse/templates/components/topic-list.hbs
@@ -24,6 +24,11 @@
               tagsForUser=tagsForUser
             }}
           </div>
+          {{raw
+            "list/visited-line"
+            lastVisitedTopic=lastVisitedTopic
+            topic=topic
+          }}
         {{/if}}
       {{/each}}
     </div>

--- a/javascripts/discourse/templates/list/visited-line.hbr
+++ b/javascripts/discourse/templates/list/visited-line.hbr
@@ -1,0 +1,8 @@
+{{! https://github.com/discourse/discourse/blob/3e897749084faeb29eb9a524d3f3b3f1d46a8738/app/assets/javascripts/discourse/templates/list/visited-line.hbr }}
+{{#if view.isLastVisited}}
+  <div class="dc-col-12">
+    <div class="dc-topic-divider">
+      {{i18n "topics.new_messages_marker"}}
+    </div>
+  </div>
+{{/if}}

--- a/scss/templates/list/visited-line.scss
+++ b/scss/templates/list/visited-line.scss
@@ -1,0 +1,31 @@
+$divider-color: $primary;
+
+.dc-topic-divider {
+  color: $divider-color;
+  text-align: center;
+  margin: 0 0 $spacer;
+  position: relative;
+
+  &::after,
+  &::before {
+    content: "";
+    display: block;
+    height: 0.0625rem;
+    width: 35%;
+    background-color: $divider-color;
+    position: relative;
+
+    @include media-breakpoint-up(md) {
+      width: 45%;
+    }
+  }
+
+  &::before {
+    top: 0.75rem;
+  }
+
+  &::after {
+    margin-left: auto;
+    top: -0.75rem;
+  }
+}

--- a/scss/widgets/header.scss
+++ b/scss/widgets/header.scss
@@ -13,7 +13,7 @@
 }
 
 .d-header .header-buttons {
-  order: 2;
+  order: 3;
   margin: 0 0 0 0.5rem;
 }
 


### PR DESCRIPTION
**What:**
Add a line to separate the topics that have any updates from last visited

**Why:**
Closes https://app.asana.com/0/1159164196409156/1168068725630293

**How:**
Use Discourse built-in approach with custom template

**Media:**
![image](https://user-images.githubusercontent.com/1425162/77683002-0e121680-6f98-11ea-831a-7bcf47f05ec5.png)
