### PR TITLE
Add header aux class to detect logged user and update items

### DIFF
--- a/javascripts/discourse/initializers/dc-header.js.es6
+++ b/javascripts/discourse/initializers/dc-header.js.es6
@@ -6,6 +6,11 @@ export default {
   initialize() {
     withPluginApi("0.8", api => {
       api.modifyClass("component:site-header", {
+        _bindUserClass() {
+          if (this.currentUser) {
+            $("d-header").addClass("with-user");
+          }
+        },
         _updateSearchIcon() {
           const searchButton = this.element.querySelector("#search-button");
 
@@ -18,6 +23,7 @@ export default {
         afterRender() {
           this._super();
           this._updateSearchIcon();
+          this._bindUserClass();
         }
       });
 

--- a/scss/widgets/header.scss
+++ b/scss/widgets/header.scss
@@ -17,6 +17,10 @@
   margin: 0 0 0 0.5rem;
 }
 
+.d-header.with-user .header-buttons {
+  order: 2;
+}
+
 .d-header-icons {
   align-items: center;
   display: flex;


### PR DESCRIPTION
**What:**
Update header-buttons order when user has logged that in order to avoid:
![image](https://user-images.githubusercontent.com/1425162/77943577-b89e7800-72bd-11ea-868b-e3f87f29db35.png)


**Why:**
We use to fix it https://github.com/debtcollective/discourse-debtcollective-theme/pull/31 and it come up again now in logged cases

**How:**
Add aux class to make difference on header when user logged and when it is not
