### PR TITLE
fix(header): typo on class selector

### DIFF
--- a/javascripts/discourse/initializers/dc-header.js.es6
+++ b/javascripts/discourse/initializers/dc-header.js.es6
@@ -8,7 +8,7 @@ export default {
       api.modifyClass("component:site-header", {
         _bindUserClass() {
           if (this.currentUser) {
-            $("d-header").addClass("with-user");
+            $(".d-header").addClass("with-user");
           }
         },
         _updateSearchIcon() {


### PR DESCRIPTION
**What:**
After rush the solution at https://github.com/debtcollective/discourse-debtcollective-theme/pull/37 I miss a `.` within class selector

**Why:**
We need the selector to be right to properly add the class

**How:**
Add the `.` to the selector