### PR TITLE
Integrate "show more" with loading flow

### DIFF
--- a/javascripts/discourse/components/dc-show-more.js.es6
+++ b/javascripts/discourse/components/dc-show-more.js.es6
@@ -17,6 +17,7 @@ export default Component.extend({
 
   didInsertElement() {
     this._ensureVisibleElements();
+    this._hideLoadingMessage();
   },
 
   willUpdate() {
@@ -27,6 +28,21 @@ export default Component.extend({
   toggleExpanded() {
     this.set("displayButton", this.collapsable);
     this.set("isExpanded", !this.isExpanded);
+
+    this._hideLoadingMessage();
+  },
+
+  /**
+   * avoid to show the message of "no more topics" if not expanded yet
+   * prevent to show the loading spinner until component gets expanded
+   */
+  _hideLoadingMessage() {
+    const loadingContainerSelectors = [".topic-list-bottom"];
+
+    $(loadingContainerSelectors.join(",")).css(
+      "display",
+      this.isExpanded ? "block" : "none"
+    );
   },
 
   _ensureVisibleElements() {

--- a/javascripts/discourse/components/dc-show-more.js.es6
+++ b/javascripts/discourse/components/dc-show-more.js.es6
@@ -12,16 +12,11 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
-    this._updateDisplayText();
   },
 
   didInsertElement() {
     this._ensureVisibleElements();
     this._hideLoadingMessage();
-  },
-
-  willUpdate() {
-    this._updateDisplayText();
   },
 
   @action
@@ -53,14 +48,5 @@ export default Component.extend({
     if (hasVisibleElements) return;
 
     this.toggleExpanded();
-  },
-
-  _updateDisplayText() {
-    this.set(
-      "displayText",
-      this.isExpanded
-        ? I18n.t(themePrefix("dc.show_more.expanded"))
-        : I18n.t(themePrefix("dc.show_more.collapsed"))
-    );
   }
 });

--- a/javascripts/discourse/components/dc-show-more.js.es6
+++ b/javascripts/discourse/components/dc-show-more.js.es6
@@ -16,13 +16,7 @@ export default Component.extend({
   },
 
   didInsertElement() {
-    const visibleElementsClass = ".show-more-visible-true";
-    const hasVisibleElements =
-      this.element.querySelectorAll(visibleElementsClass).length > 0;
-
-    if (hasVisibleElements) return;
-
-    this.toggleExpanded();
+    this._ensureVisibleElements();
   },
 
   willUpdate() {
@@ -33,6 +27,16 @@ export default Component.extend({
   toggleExpanded() {
     this.set("displayButton", this.collapsable);
     this.set("isExpanded", !this.isExpanded);
+  },
+
+  _ensureVisibleElements() {
+    const visibleElementsClass = ".show-more-visible-true";
+    const hasVisibleElements =
+      this.element.querySelectorAll(visibleElementsClass).length > 0;
+
+    if (hasVisibleElements) return;
+
+    this.toggleExpanded();
   },
 
   _updateDisplayText() {

--- a/javascripts/discourse/templates/components/dc-show-more.hbs
+++ b/javascripts/discourse/templates/components/dc-show-more.hbs
@@ -1,6 +1,6 @@
 {{yield}}
 {{#if displayButton}}
   <button class="btn-show-more" {{on "click" this.toggleExpanded}}>
-    {{displayText}}
+    {{theme-i18n "dc.show_more.collapsed"}}
   </button>
 {{/if}}


### PR DESCRIPTION
**What:**
Hide the loading container until component gets expanded

**Why:**
Closes https://app.asana.com/0/1168997577035609/board

The idea is to avoid to show a "show more" button with a text that already said "there is nothing more" or perhaps the loading spinner.

**How:**
- Add a "loadingContainerSelectors" within a new method "_hideLoadingMessage" that will address the problem within the topic list _(only place we currently use the show more component)_
- Small refactor to enclose intended actions on lifecycle within a method

**Media:**
![https://recordit.co/G3WrLPYwwx](https://recordit.co/G3WrLPYwwx.gif)