### PR TITLE
Current efforts within homepage

### DIFF
--- a/javascripts/discourse/components/categories-only.js.es6
+++ b/javascripts/discourse/components/categories-only.js.es6
@@ -14,5 +14,10 @@ export default Component.extend({
   nonCollectives(categories) {
     const _categories = categories.content;
     return _categories.filter(c => !c.is_collective);
+  },
+
+  @discourseComputed("topics")
+  currentEfforts(topics) {
+    return topics.filter(topic => topic.pinned);
   }
 });

--- a/javascripts/discourse/components/categories-only.js.es6
+++ b/javascripts/discourse/components/categories-only.js.es6
@@ -6,14 +6,12 @@ export default Component.extend({
 
   @discourseComputed("categories")
   collectives(categories) {
-    const _categories = categories.content;
-    return _categories.filter(c => c.is_collective);
+    return categories.filter(category => category.is_collective);
   },
 
   @discourseComputed("categories")
   nonCollectives(categories) {
-    const _categories = categories.content;
-    return _categories.filter(c => !c.is_collective);
+    return categories.filter(category => !category.is_collective);
   },
 
   @discourseComputed("topics")

--- a/javascripts/discourse/components/categories-only.js.es6
+++ b/javascripts/discourse/components/categories-only.js.es6
@@ -1,0 +1,18 @@
+import discourseComputed from "discourse-common/utils/decorators";
+import Component from "@ember/component";
+
+export default Component.extend({
+  tagName: "div",
+
+  @discourseComputed("categories")
+  collectives(categories) {
+    const _categories = categories.content;
+    return _categories.filter(c => c.is_collective);
+  },
+
+  @discourseComputed("categories")
+  nonCollectives(categories) {
+    const _categories = categories.content;
+    return _categories.filter(c => !c.is_collective);
+  }
+});

--- a/javascripts/discourse/templates/components/categories-and-latest-topics.hbs
+++ b/javascripts/discourse/templates/components/categories-and-latest-topics.hbs
@@ -1,4 +1,4 @@
-{{!-- https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/components/categories-and-latest-topics.hbs --}}
-<div class='column categories'>
-  {{categories-only categories=categories}}
+{{! https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/components/categories-and-latest-topics.hbs }}
+<div class="column categories">
+  {{categories-only categories=categories topics=topics}}
 </div>

--- a/javascripts/discourse/templates/components/categories-only.hbs
+++ b/javascripts/discourse/templates/components/categories-only.hbs
@@ -1,2 +1,2 @@
 {{! https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/components/categories-only.hbs }}
-{{dc-categories-only categories=categories}}
+{{dc-categories-only nonCollectives=nonCollectives collectives=collectives}}

--- a/javascripts/discourse/templates/components/categories-only.hbs
+++ b/javascripts/discourse/templates/components/categories-only.hbs
@@ -1,2 +1,6 @@
 {{! https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/components/categories-only.hbs }}
-{{dc-categories-only nonCollectives=nonCollectives collectives=collectives}}
+{{dc-categories-only
+  nonCollectives=nonCollectives
+  collectives=collectives
+  currentEfforts=currentEfforts
+}}

--- a/javascripts/discourse/templates/components/dc-categories-only.hbs
+++ b/javascripts/discourse/templates/components/dc-categories-only.hbs
@@ -1,19 +1,21 @@
-{{#if currentEfforts}}
-  <div class="dc-categories-container">
-    <h2 class="dc-heading">
-      {{theme-i18n "dc.categories.currentEfforts.title"}}
-    </h2>
-    <p>
-      {{{theme-i18n "dc.categories.currentEfforts.description"}}}
-    </p>
-    <div class="dc-row">
-      {{#each currentEfforts as |t|}}
-        <div class="dc-col-sm-4">
-          {{dc-topic-list-item-small topic=t}}
-        </div>
-      {{/each}}
+{{#if themeSettings.show_current_efforts}}
+  {{#if currentEfforts}}
+    <div class="dc-categories-container">
+      <h2 class="dc-heading">
+        {{theme-i18n "dc.categories.currentEfforts.title"}}
+      </h2>
+      <p>
+        {{{theme-i18n "dc.categories.currentEfforts.description"}}}
+      </p>
+      <div class="dc-row">
+        {{#each currentEfforts as |t|}}
+          <div class="dc-col-sm-4">
+            {{dc-topic-list-item-small topic=t}}
+          </div>
+        {{/each}}
+      </div>
     </div>
-  </div>
+  {{/if}}
 {{/if}}
 {{#if collectives}}
   <div class="dc-categories-container">

--- a/javascripts/discourse/templates/components/dc-categories-only.hbs
+++ b/javascripts/discourse/templates/components/dc-categories-only.hbs
@@ -1,3 +1,20 @@
+{{#if currentEfforts}}
+  <div class="dc-categories-container">
+    <h2 class="dc-heading">
+      {{theme-i18n "dc.categories.currentEfforts.title"}}
+    </h2>
+    <p>
+      {{{theme-i18n "dc.categories.currentEfforts.description"}}}
+    </p>
+    <div class="dc-row">
+      {{#each currentEfforts as |t|}}
+        <div class="dc-col-sm-4">
+          {{dc-topic-list-item-small topic=t}}
+        </div>
+      {{/each}}
+    </div>
+  </div>
+{{/if}}
 {{#if collectives}}
   <div class="dc-categories-container">
     <h2 class="dc-heading">

--- a/javascripts/discourse/templates/components/dc-categories-only.hbs
+++ b/javascripts/discourse/templates/components/dc-categories-only.hbs
@@ -1,5 +1,4 @@
-{{! TODO: https://github.com/debtcollective/community/issues/32 }}
-{{#if categories}}
+{{#if collectives}}
   <div class="dc-categories-container">
     <h2 class="dc-heading">
       {{theme-i18n "dc.categories.collectives.title"}}
@@ -8,28 +7,24 @@
       {{{theme-i18n "dc.categories.collectives.description"}}}
     </p>
     <div class="dc-row">
-      {{#each categories as |c|}}
-        {{#if c.is_collective}}
-          <div class="dc-col-sm-6">
-            {{dc-category-card category=c}}
-          </div>
-        {{/if}}
+      {{#each collectives as |c|}}
+        <div class="dc-col-sm-6">
+          {{dc-category-card category=c}}
+        </div>
       {{/each}}
     </div>
   </div>
 {{/if}}
-{{#if categories}}
+{{#if nonCollectives}}
   <div class="dc-categories-container">
     <h2 class="dc-heading">
       {{theme-i18n "dc.categories.others.title"}}
     </h2>
     <div class="dc-row">
-      {{#each categories as |c|}}
-        {{#unless c.is_collective}}
-          <div class="dc-col-sm-6">
-            {{dc-category-card category=c}}
-          </div>
-        {{/unless}}
+      {{#each nonCollectives as |c|}}
+        <div class="dc-col-sm-6">
+          {{dc-category-card category=c}}
+        </div>
       {{/each}}
     </div>
   </div>

--- a/javascripts/discourse/templates/mobile/components/categories-only.hbs
+++ b/javascripts/discourse/templates/mobile/components/categories-only.hbs
@@ -1,2 +1,2 @@
 {{! https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/mobile/components/categories-only.hbs }}
-{{dc-categories-only categories=categories}}
+{{dc-categories-only nonCollectives=nonCollectives collectives=collectives}}

--- a/javascripts/discourse/templates/mobile/components/categories-only.hbs
+++ b/javascripts/discourse/templates/mobile/components/categories-only.hbs
@@ -1,2 +1,6 @@
 {{! https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/mobile/components/categories-only.hbs }}
-{{dc-categories-only nonCollectives=nonCollectives collectives=collectives}}
+{{dc-categories-only
+  nonCollectives=nonCollectives
+  collectives=collectives
+  currentEfforts=currentEfforts
+}}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -9,6 +9,10 @@ en:
       expanded: "Show less topics"
       collapsed: "Show more topics"
     categories:
+      currentEfforts:
+        title: "Current efforts"
+        description: "We strive to make accessible to you all the efforts that are happening right now around the debt collective organization. 
+        Below you can find some of those. Keep exploring the community to find out more"
       collectives: 
         title: "Our Collectives"
         description: "When you join the Debt Collective you will be placed into a group based on your debt type. We call these groups <strong>collectives</strong>.

--- a/scss/templates/list/dc-topic-card.scss
+++ b/scss/templates/list/dc-topic-card.scss
@@ -18,7 +18,6 @@
 
 .dc-topic-small.dc-card {
   padding-bottom: 0;
-  height: 10.5rem;
 
   .dc-card__title {
     font-size: $font-size-base;

--- a/settings.yml
+++ b/settings.yml
@@ -7,3 +7,6 @@ header_categories:
 show_hero:
   type: bool
   default: true
+show_current_efforts:
+  type: bool
+  default: false


### PR DESCRIPTION
**What:**
Add a section that allows to render pinned topics in form of "current efforts"

**Why:**
Closes https://app.asana.com/0/1168997577035609/1168068725630291

**How:**
We inject the current topic data we have on the homepage into the `category-only` template and then filter pinned topics within `currentEfforts`.

**Extras:**
- Optimise the `categories-only` template to not need double iteration over categories. 6dc74b1
- Remove fixed height for `topic-small` 88b5b2b

🚨**Important:**
The homepage only have access to the ["latest topics" check discourse core code](https://github.com/discourse/discourse/blob/38dd184a16f38fed1f011eeb39de580a301b8f4e/app/assets/javascripts/discourse/routes/discovery-categories.js.es6#L48) so we need to deliver to the client the pinned topics so we can render properly the current efforts.

**Media:**
![image](https://user-images.githubusercontent.com/1425162/78992669-12176a00-7b3c-11ea-840a-b087b9943129.png)
