### PR TITLE
Avoid fatal error for empty topics

### DIFF
--- a/javascripts/discourse/components/categories-only.js.es6
+++ b/javascripts/discourse/components/categories-only.js.es6
@@ -16,6 +16,6 @@ export default Component.extend({
 
   @discourseComputed("topics")
   currentEfforts(topics) {
-    return topics.filter(topic => topic.pinned);
+    return (topics && topics.filter(topic => topic.pinned)) || [];
   }
 });

--- a/javascripts/discourse/templates/components/dc-categories-only.hbs
+++ b/javascripts/discourse/templates/components/dc-categories-only.hbs
@@ -1,21 +1,19 @@
-{{#if themeSettings.show_current_efforts}}
-  {{#if currentEfforts}}
-    <div class="dc-categories-container">
-      <h2 class="dc-heading">
-        {{theme-i18n "dc.categories.currentEfforts.title"}}
-      </h2>
-      <p>
-        {{{theme-i18n "dc.categories.currentEfforts.description"}}}
-      </p>
-      <div class="dc-row">
-        {{#each currentEfforts as |t|}}
-          <div class="dc-col-sm-4">
-            {{dc-topic-list-item-small topic=t}}
-          </div>
-        {{/each}}
-      </div>
+{{#if currentEfforts}}
+  <div class="dc-categories-container">
+    <h2 class="dc-heading">
+      {{theme-i18n "dc.categories.currentEfforts.title"}}
+    </h2>
+    <p>
+      {{{theme-i18n "dc.categories.currentEfforts.description"}}}
+    </p>
+    <div class="dc-row">
+      {{#each currentEfforts as |t|}}
+        <div class="dc-col-sm-4">
+          {{dc-topic-list-item-small topic=t}}
+        </div>
+      {{/each}}
     </div>
-  {{/if}}
+  </div>
 {{/if}}
 {{#if collectives}}
   <div class="dc-categories-container">

--- a/javascripts/discourse/templates/mobile/components/categories-only.hbs
+++ b/javascripts/discourse/templates/mobile/components/categories-only.hbs
@@ -1,6 +1,10 @@
 {{! https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/mobile/components/categories-only.hbs }}
-{{dc-categories-only
-  nonCollectives=nonCollectives
-  collectives=collectives
-  currentEfforts=currentEfforts
-}}
+{{#if themeSettings.show_current_efforts}}
+  {{dc-categories-only
+    nonCollectives=nonCollectives
+    collectives=collectives
+    currentEfforts=currentEfforts
+  }}
+{{else}}
+  {{dc-categories-only nonCollectives=nonCollectives collectives=collectives}}
+{{/if}}


### PR DESCRIPTION
**What:**
Add default value to return by topics on currentEfforts

**Why:**
`currentEfforts` computation needs `topics` but for some reason this can be `undefined` (need to dig more into it) but currently the community is broken due to this.

**How:**
- Attempt to flag the feature up so the code doesn't get triggered
- Add fallback to empty array 8287f38