### PR TITLE
Global pinned topics

### DIFF
--- a/javascripts/discourse/initializers/dc-homepage.js.es6
+++ b/javascripts/discourse/initializers/dc-homepage.js.es6
@@ -1,0 +1,14 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+
+export default {
+  name: "dc-homepage",
+  initialize() {
+    withPluginApi("0.8", api => {
+      api.modifyClass("route:discovery-categories", {
+        findCategories() {
+          return this._findCategoriesAndTopics("latest");
+        }
+      });
+    });
+  }
+};

--- a/javascripts/discourse/templates/components/categories-and-latest-topics.hbs
+++ b/javascripts/discourse/templates/components/categories-and-latest-topics.hbs
@@ -1,4 +1,2 @@
 {{! https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/components/categories-and-latest-topics.hbs }}
-<div class="column categories">
-  {{categories-only categories=categories topics=topics}}
-</div>
+{{categories-only categories=categories topics=topics}}


### PR DESCRIPTION
**What:**
Enable global pinned topics by forcing to load latest topics within homepage

**Why:**
We need access to the latest topics to render globally pinned topics

**How:**
Update the route `discovery-categories` to always use the `this._findCategoriesAndTopics("latest")` strategy which is used to load latest topics.

**Screenshots**
![image](https://user-images.githubusercontent.com/1425162/79792249-dc9a2a00-834e-11ea-90f3-a09e874b8e24.png)

_Note: you can tested with [live community here](https://community.debtcollective.org/?preview_theme_id=15)_