### PR TITLE
feat(about): allow theme to force excerpt on topics

### DIFF
--- a/about.json
+++ b/about.json
@@ -9,5 +9,8 @@
     "Standard": {
       "primary": "222222"
     }
+  },
+  "modifiers": {
+    "serialize_topic_excerpts": true
   }
 }


### PR DESCRIPTION
**What:**
Render topic excerpt on topic list cards

**Why:**
re https://app.asana.com/0/1168997577035609/1169229929310113

**How:**
After research and [open a topic on the community](https://meta.discourse.org/t/how-to-add-topic-excerpt-to-all-my-topics/148903) we found the solution

**Media:**
![image](https://user-images.githubusercontent.com/1425162/80233146-546d9a80-8656-11ea-91f5-a3eefdc6348e.png)
