### PR TITLE
Category members count

### DIFF
--- a/javascripts/discourse/components/categories-only.js.es6
+++ b/javascripts/discourse/components/categories-only.js.es6
@@ -6,12 +6,12 @@ export default Component.extend({
 
   @discourseComputed("categories")
   collectives(categories) {
-    return categories.filter(category => category.is_collective);
+    return categories.filter(category => category.tdc_is_collective);
   },
 
   @discourseComputed("categories")
   nonCollectives(categories) {
-    return categories.filter(category => !category.is_collective);
+    return categories.filter(category => !category.tdc_is_collective);
   },
 
   @discourseComputed("topics")

--- a/javascripts/discourse/components/dc-category-card.js.es6
+++ b/javascripts/discourse/components/dc-category-card.js.es6
@@ -4,9 +4,10 @@ import { computed } from "@ember/object";
 export default Component.extend({
   groupCount: computed(function() {
     const category = this.category;
+    const isCollective = category.tdc_is_collective;
 
-    if (!category.is_collective) return null;
+    if (!isCollective) return null;
 
-    return category.collective_group.user_count;
+    return category.tdc_collective_group.user_count;
   })
 });

--- a/javascripts/discourse/components/dc-category-card.js.es6
+++ b/javascripts/discourse/components/dc-category-card.js.es6
@@ -1,0 +1,12 @@
+import Component from "@ember/component";
+import { computed } from "@ember/object";
+
+export default Component.extend({
+  groupCount: computed(function() {
+    const category = this.category;
+
+    if (!category.is_collective) return null;
+
+    return category.collective_group.user_count;
+  })
+});

--- a/javascripts/discourse/templates/components/dc-category-card.hbs
+++ b/javascripts/discourse/templates/components/dc-category-card.hbs
@@ -20,5 +20,13 @@
     <p class="m-0 ml-1 dc-text-light">
       {{category.totalTopicCount}}
     </p>
+    {{#if category.is_collective}}
+      <span class="ml-2 material-icons">
+        supervisor_account
+      </span>
+      <p class="m-0 ml-1 dc-text-light">
+        {{groupCount}}
+      </p>
+    {{/if}}
   </div>
 </a>

--- a/javascripts/discourse/templates/components/dc-category-card.hbs
+++ b/javascripts/discourse/templates/components/dc-category-card.hbs
@@ -20,7 +20,7 @@
     <p class="m-0 ml-1 dc-text-light">
       {{category.totalTopicCount}}
     </p>
-    {{#if category.is_collective}}
+    {{#if category.tdc_is_collective}}
       <span class="ml-2 material-icons">
         supervisor_account
       </span>


### PR DESCRIPTION
**What:**
Allow to render members count

**Why:**
re https://app.asana.com/0/1168997577035609/1166394121215209

**How:**
- Create a new component that expose `groupCount` into category card

**Media:**
[Categories that are not collectives doesn't have members count](https://user-images.githubusercontent.com/1425162/80246498-ce108300-866c-11ea-8069-c922086f3904.png)

![image](https://user-images.githubusercontent.com/1425162/80246480-c3ee8480-866c-11ea-963b-08af3080267f.png)

**Notes:**
This PR needs https://github.com/debtcollective/discourse-debtcollective-collectives/pull/3 to work as expected on production