### PR TITLE
feat(home-logo): allow to set home logo href using settings

### DIFF
--- a/javascripts/discourse/initializers/dc-home-logo.js.es6
+++ b/javascripts/discourse/initializers/dc-home-logo.js.es6
@@ -1,0 +1,14 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+
+export default {
+  name: "dc-home-logo",
+  initialize() {
+    withPluginApi("0.8", api => {
+      api.reopenWidget("home-logo", {
+        settings: {
+          href: settings.logo_href || Discourse.getURL("/")
+        }
+      });
+    });
+  }
+};

--- a/settings.yml
+++ b/settings.yml
@@ -10,3 +10,6 @@ show_hero:
 show_current_efforts:
   type: bool
   default: false
+logo_href:
+  type: string
+  default: ""


### PR DESCRIPTION
**What:**
Allow to change the logo href without code

**Why:**
This is a change that product as asked for, as from a tech perspective
seems to not be a good decision we enable the flexibility to easily tweak it

re https://app.asana.com/0/1168997577035609/1172273375528964

**How:**
Define a setting from the theme that take effect on the home-logo widget.