### PR TITLE
fix: rename toggleBookmarkWithReminder to toggleBookmark

### DIFF
--- a/javascripts/discourse/templates/topic.hbs
+++ b/javascripts/discourse/templates/topic.hbs
@@ -43,7 +43,6 @@
                 expandHidden=(action "expandHidden")
                 newTopicAction=(action "replyAsNewTopic")
                 toggleBookmark=(action "toggleBookmark")
-                toggleBookmarkWithReminder=(action "toggleBookmarkWithReminder")
                 togglePostType=(action "togglePostType")
                 rebakePost=(action "rebakePost")
                 changePostOwner=(action "changePostOwner")


### PR DESCRIPTION
**We need to sync the deployment of this, first Discourse needs to be updated before we can update the theme on production**

**What:** rename toggleBookmarkWithReminder to toggleBookmark

following the change on Discourse https://github.com/discourse/discourse/pull/9579

**Why:** To make the theme work with the latest Discourse version

**How:**

- rename toggleBookmarkWithReminder to toggleBookmark