### PR TITLE
Category page navigation improvements

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -17,8 +17,10 @@
 @import "connectors/hero";
 
 @import "templates/components/categories-only";
+@import "templates/components/d-navigation";
 @import "templates/components/dc-show-more";
 @import "templates/components/list-controls";
+@import "templates/components/navigation-bar";
 @import "templates/components/topic-list";
 @import "templates/composer";
 @import "templates/topic";

--- a/common/common.scss
+++ b/common/common.scss
@@ -17,25 +17,25 @@
 @import "connectors/hero";
 
 @import "templates/components/categories-only";
-@import "templates/components/topic-list";
 @import "templates/components/dc-show-more";
 @import "templates/components/list-controls";
+@import "templates/components/topic-list";
+@import "templates/composer";
 @import "templates/topic";
 @import "templates/user";
-@import "templates/composer";
 
 @import "templates/list/dc-topic-author";
 @import "templates/list/dc-topic-card";
 @import "templates/list/visited-line";
 
-@import "widgets/header";
-@import "widgets/post";
-@import "widgets/post-controls";
 @import "widgets/embedded-posts";
+@import "widgets/header";
+@import "widgets/post-controls";
+@import "widgets/post";
+@import "widgets/quick-access-panel";
 @import "widgets/select-kit";
 @import "widgets/topic-timeline";
 @import "widgets/user-menu";
-@import "widgets/quick-access-panel";
 
 // Re-apply foundation styles with different variables to overwrite rules
 

--- a/javascripts/discourse/components/dc-show-more.js.es6
+++ b/javascripts/discourse/components/dc-show-more.js.es6
@@ -41,11 +41,13 @@ export default Component.extend({
   },
 
   _ensureVisibleElements() {
+    const { pathname: currentPage } = window.location;
     const visibleElementsClass = ".show-more-visible-true";
+    const blacklistedPages = ["/latest"];
     const hasVisibleElements =
       this.element.querySelectorAll(visibleElementsClass).length > 0;
 
-    if (hasVisibleElements) return;
+    if (hasVisibleElements && !blacklistedPages.includes(currentPage)) return;
 
     this.toggleExpanded();
   }

--- a/javascripts/discourse/initializers/dc-navigation.js.es6
+++ b/javascripts/discourse/initializers/dc-navigation.js.es6
@@ -1,0 +1,16 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+import discourseComputed from "discourse-common/utils/decorators";
+
+export default {
+  name: "dc-navigation",
+  initialize() {
+    withPluginApi("0.8", api => {
+      api.modifyClass("component:d-navigation", {
+        @discourseComputed("filterMode")
+        isLatestPage(filterMode) {
+          return filterMode === "latest";
+        }
+      });
+    });
+  }
+};

--- a/javascripts/discourse/templates/components/d-navigation.hbs
+++ b/javascripts/discourse/templates/components/d-navigation.hbs
@@ -1,0 +1,45 @@
+{{bread-crumbs
+  categories=categories
+  category=category
+  noSubcategories=noSubcategories
+}}
+<p class="category-description">
+  {{category.description}}
+</p>
+{{navigation-bar navItems=navItems filterMode=filterMode category=category}}
+<div class="category-actions">
+  {{#if showCategoryAdmin}}
+    {{categories-admin-dropdown
+      onChange=(action "selectCategoryAdminDropdownAction")
+    }}
+  {{/if}}
+  {{#if showCategoryNotifications}}
+    {{category-notifications-button
+      value=category.notification_level
+      category=category
+      onChange=(action "changeCategoryNotificationLevel")
+    }}
+  {{/if}}
+  {{plugin-outlet
+    name="before-create-topic-button"
+    args=(hash
+      canCreateTopic=canCreateTopic
+      createTopicDisabled=createTopicDisabled
+      createTopicLabel=createTopicLabel
+    )
+  }}
+  {{create-topic-button
+    canCreateTopic=canCreateTopic
+    action=createTopic
+    disabled=createTopicDisabled
+    label=createTopicLabel
+  }}
+  {{#if showCategoryEdit}}
+    {{d-button
+      class="btn-default edit-category"
+      action=editCategory
+      icon="wrench"
+      label="category.edit"
+    }}
+  {{/if}}
+</div>

--- a/javascripts/discourse/templates/components/d-navigation.hbs
+++ b/javascripts/discourse/templates/components/d-navigation.hbs
@@ -3,9 +3,16 @@
   category=category
   noSubcategories=noSubcategories
 }}
-<p class="category-description">
-  {{category.description}}
-</p>
+{{#if isLatestPage}}
+  <p class="page-description">
+    In this section you will find everything that is happening right now within the community
+  </p>
+{{/if}}
+{{#if category}}
+  <p class="category-description">
+    {{category.description}}
+  </p>
+{{/if}}
 {{navigation-bar navItems=navItems filterMode=filterMode category=category}}
 <div class="category-actions">
   {{#if showCategoryAdmin}}

--- a/javascripts/discourse/templates/discovery.hbs
+++ b/javascripts/discourse/templates/discovery.hbs
@@ -1,0 +1,33 @@
+{{! https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/app/templates/discovery.hbs }}
+{{#if errorHtml}}
+  {{html-safe errorHtml}}
+{{else}}
+  <div class="container">
+    {{discourse-banner user=currentUser banner=site.banner}}
+  </div>
+  {{#if category}}
+    {{outlet "navigation-bar"}}
+  {{/if}}
+  {{conditional-loading-spinner condition=loading}}
+  <div class="container list-container {{if loading "hidden"}}">
+    <div class="row">
+      <div class="full-width">
+        <div id="header-list-area">
+          {{outlet "header-list-container"}}
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="full-width">
+        <div id="list-area">
+          {{plugin-outlet
+            name="discovery-list-container-top"
+            args=(hash category=category listLoading=loading)
+          }}
+          {{outlet "list-container"}}
+        </div>
+      </div>
+    </div>
+  </div>
+  {{plugin-outlet name="discovery-below"}}
+{{/if}}

--- a/javascripts/discourse/templates/discovery.hbs
+++ b/javascripts/discourse/templates/discovery.hbs
@@ -5,9 +5,11 @@
   <div class="container">
     {{discourse-banner user=currentUser banner=site.banner}}
   </div>
-  {{#if category}}
-    {{outlet "navigation-bar"}}
-  {{/if}}
+  <div class="list-controls">
+    <div class="container">
+      {{outlet "navigation-bar"}}
+    </div>
+  </div>
   {{conditional-loading-spinner condition=loading}}
   <div class="container list-container {{if loading "hidden"}}">
     <div class="row">

--- a/javascripts/discourse/templates/navigation/default.hbs
+++ b/javascripts/discourse/templates/navigation/default.hbs
@@ -1,0 +1,16 @@
+{{#d-section
+  bodyClass="navigation-topics"
+  class="navigation-container"
+  scrollTop="false"
+}}
+  {{! We need to add a extra wrapper to being able to target this with CSS }}
+  {{! Trying to customise with navigation-container won't take effect }}
+  <div class="dc-navigation-container">
+    {{d-navigation
+      filterMode=filterMode
+      canCreateTopic=canCreateTopic
+      hasDraft=draft
+      createTopic=(route-action "createTopic")
+    }}
+  </div>
+{{/d-section}}

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -27,3 +27,64 @@
     margin-top: 1rem;
   }
 }
+
+#navigation-bar {
+  border: none;
+
+  .navigation-toggle {
+    border-radius: 0.25rem;
+    margin: 0;
+  }
+
+  .navigation-toggle .toggle-link {
+    border: none;
+    top: 0;
+    padding: 0.1875rem 0.625rem;
+  }
+}
+
+.list-controls {
+  .container #create-topic {
+    margin: 0;
+  }
+
+  .nav-pills .drop {
+    padding: 0;
+  }
+
+  .nav-pills .drop li {
+    margin: 0;
+    padding: 0;
+
+    a[href="/categories"] {
+      display: none;
+    }
+
+    a {
+      padding: 0.625rem;
+    }
+  }
+
+  .btn:not(.select-kit-header),
+  .btn,
+  .select-kit:not(.category-drop) {
+    margin: 0;
+    margin-right: 0.625rem;
+  }
+}
+
+ol.category-breadcrumb .select-kit.combo-box .select-kit-header {
+  font-size: 1.5rem;
+}
+
+.dc-navigation-container,
+.category-navigation {
+  .category-actions {
+    align-items: center;
+    display: flex;
+    margin-top: 1rem;
+    position: relative;
+    top: 0;
+    width: 100%;
+  }
+}

--- a/scss/templates/components/d-navigation.scss
+++ b/scss/templates/components/d-navigation.scss
@@ -1,0 +1,58 @@
+.category-navigation {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  margin-bottom: 3rem;
+  position: relative;
+
+  .category-description {
+    margin-top: 0;
+  }
+
+  .category-breadcrumb,
+  .category-description {
+    flex: 1;
+    float: none;
+    min-width: 100%;
+  }
+
+  .category-actions {
+    position: absolute;
+    top: 0;
+    right: 0;
+  }
+
+  .category-notifications-button > button.dropdown-select-box-header {
+    padding: 0.4375rem;
+    min-height: 0;
+    border-radius: 0.25rem;
+  }
+}
+
+ol.category-breadcrumb {
+  margin: 0;
+
+  .select-kit.combo-box .select-kit-header {
+    background: transparent;
+    border: none;
+    font-size: 2rem;
+    padding: 0;
+  }
+
+  .select-kit.single-select.is-expanded .select-kit-header {
+    outline: none;
+  }
+
+  .badge-wrapper.bullet {
+    align-items: center;
+    display: flex;
+
+    .badge-category {
+      color: $gray;
+    }
+
+    .badge-category-bg {
+      margin-right: 0.5rem;
+    }
+  }
+}

--- a/scss/templates/components/d-navigation.scss
+++ b/scss/templates/components/d-navigation.scss
@@ -1,10 +1,39 @@
-.category-navigation {
+.category-navigation,
+.dc-navigation-container {
   align-items: center;
   display: flex;
   flex-wrap: wrap;
-  margin-bottom: 3rem;
   position: relative;
+  width: 100%;
+}
 
+.dc-navigation-container {
+  .category-breadcrumb {
+    flex: 1;
+    float: none;
+    min-width: 100%;
+  }
+
+  .category-actions {
+    position: absolute;
+    top: 0.25rem;
+    right: 0;
+  }
+
+  .page-description {
+    flex: 1;
+    float: none;
+    margin: 0 0 1rem;
+    min-width: 100%;
+  }
+
+  // Avoid to show the link to catefories that will make the user go to the homepage
+  a[href="/categories"] {
+    display: none;
+  }
+}
+
+.category-navigation {
   .category-description {
     margin-top: 0;
   }
@@ -18,7 +47,7 @@
 
   .category-actions {
     position: absolute;
-    top: 0;
+    top: 0.25rem;
     right: 0;
   }
 
@@ -30,6 +59,7 @@
 }
 
 ol.category-breadcrumb {
+  float: none;
   margin: 0;
 
   .select-kit.combo-box .select-kit-header {

--- a/scss/templates/components/d-navigation.scss
+++ b/scss/templates/components/d-navigation.scss
@@ -52,7 +52,7 @@
   }
 
   .category-notifications-button > button.dropdown-select-box-header {
-    padding: 0.4375rem;
+    padding: 0.375rem 0.75rem;
     min-height: 0;
     border-radius: 0.25rem;
   }

--- a/scss/templates/components/list-controls.scss
+++ b/scss/templates/components/list-controls.scss
@@ -11,6 +11,9 @@ body {
 }
 
 .list-controls {
+  margin-top: 2rem;
+  margin-bottom: 3rem;
+
   .select-kit.categories-admin-dropdown,
   .select-kit.tags-admin-dropdown,
   .select-kit.category-notifications-button,
@@ -18,18 +21,6 @@ body {
   .navigation-container {
     display: flex;
     align-items: center;
-  }
-
-  #navigation-bar {
-    margin-right: auto;
-  }
-
-  ol.category-breadcrumb {
-    margin-bottom: 0;
-  }
-
-  ol.category-breadcrumb li {
-    margin-right: 0;
   }
 
   #create-topic,
@@ -56,19 +47,9 @@ body {
     margin: 0;
   }
 
-  .navigation-container > * {
-    margin-bottom: 0;
-  }
-
   .nav,
   .btn {
     margin-top: 0;
     margin-bottom: 0;
-  }
-
-  .category-navigation {
-    display: flex;
-    align-items: center;
-    width: 100%;
   }
 }

--- a/scss/templates/components/navigation-bar.scss
+++ b/scss/templates/components/navigation-bar.scss
@@ -1,0 +1,35 @@
+#navigation-bar {
+  border-bottom: 0.125rem solid $gray-ligth;
+  display: flex;
+  flex: 1;
+  margin: 0;
+}
+
+.nav.nav-pills {
+  > li {
+    float: none;
+    margin: 0;
+  }
+
+  > li a {
+    background: none;
+    border: 0.125rem solid transparent;
+    position: relative;
+    top: 0.125rem;
+    transition: all ease 0.216s;
+    padding: 0.75rem 1rem;
+  }
+
+  > li a.active {
+    background: none;
+  }
+
+  > li a.active {
+    border-bottom-color: $primary;
+    color: $primary;
+  }
+
+  > li > a:hover {
+    color: $primary;
+  }
+}

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -2,6 +2,7 @@
 $beige: #fbfbfb;
 $blue: #03a9f4;
 $gray: #2b2b2b;
+$gray-ligth: #bdbdbd;
 $green: #2dcbad;
 $purple: #dac4f5;
 $red: #ff4630;

--- a/scss/widgets/select-kit.scss
+++ b/scss/widgets/select-kit.scss
@@ -5,3 +5,7 @@
   border: 0.0625rem solid $gray-300;
   padding: 0.5rem 0.75rem;
 }
+
+.select-kit.single-select.is-expanded .select-kit-header {
+  outline: auto 5px -webkit-focus-ring-color;
+}


### PR DESCRIPTION
**What:**
Improve the customization of the navigation item

**Why:**
It used to feel off from the theme and also some details make it confusing.
re https://app.asana.com/0/1168997577035609/board

**How:**
- Customise the navigation component
- Add title and description of the category as a more explicit content on the page
- Remove link to go to categories when latest so we avoid confusion with global latest and home
- Prevent show more to take place on latest page

**Media**
![Desktop](https://user-images.githubusercontent.com/1425162/81973918-2233d500-9625-11ea-8550-91c50a5ab936.png)

- [Loom video](https://www.loom.com/share/8e356da2b94d4442909a3258da491caa)
- [Mobile screenshot](https://user-images.githubusercontent.com/1425162/81974051-4d1e2900-9625-11ea-8ee8-9faaa8568102.png)