### PR TITLE
Fixes category page

### DIFF
--- a/javascripts/discourse/templates/components/d-navigation.hbs
+++ b/javascripts/discourse/templates/components/d-navigation.hbs
@@ -1,3 +1,4 @@
+{{! https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs }}
 {{bread-crumbs
   categories=categories
   category=category

--- a/javascripts/discourse/templates/components/d-navigation.hbs
+++ b/javascripts/discourse/templates/components/d-navigation.hbs
@@ -11,7 +11,7 @@
 {{/if}}
 {{#if category}}
   <p class="category-description">
-    {{category.description}}
+    {{{category.description}}}
   </p>
 {{/if}}
 {{navigation-bar navItems=navItems filterMode=filterMode category=category}}

--- a/scss/templates/components/d-navigation.scss
+++ b/scss/templates/components/d-navigation.scss
@@ -34,10 +34,6 @@
 }
 
 .category-navigation {
-  .category-description {
-    margin-top: 0;
-  }
-
   .category-breadcrumb,
   .category-description {
     flex: 1;

--- a/scss/templates/components/navigation-bar.scss
+++ b/scss/templates/components/navigation-bar.scss
@@ -6,6 +6,8 @@
 }
 
 .nav.nav-pills {
+  display: flex;
+
   > li {
     float: none;
     margin: 0;


### PR DESCRIPTION
**What:**
Make sure description support rich text

**Why:**
The description of a category is being done with a topic "About topic", the content of this is a rich text and we should show it as such. (Allowing to use links, bold, italic... etc)

**How:**
- Use hbs built-in solution `{{{value}}}`
- Add remote URL for d-navigation component

**Media**
[Before the description was displayed as shown here](https://user-images.githubusercontent.com/1425162/82149684-6f978880-9857-11ea-980c-83263ff9b7f8.png)

![image](https://user-images.githubusercontent.com/1425162/82149754-85a54900-9857-11ea-9487-32e6ee9eba16.png)
