### PR TITLE
Add popup to the community page

### DIFF
--- a/javascripts/discourse/initializers/dc-popup.js.es6
+++ b/javascripts/discourse/initializers/dc-popup.js.es6
@@ -18,14 +18,11 @@ export default {
           "dc-popup",
           {
             id: "dc-popup",
-            hero: "We've got a new look! What do you think?",
+            hero: I18n.t(themePrefix("dc.popup.title")),
             class: "hydrated",
-            url:
-              "https://community.debtcollective.org/t/user-experience-feedback-new-theme/4110"
+            url: settings.popup_url
           },
-          `Noticed the new layout for the Debt Collective Community platform? Implementing this took a
-              lot of time and effort and we want to make sure the new system works for you.
-              So, please let us know what is working well and what you may want to see done better!`
+          I18n.t(themePrefix("dc.popup.description"))
         );
 
         popupEnabled = true;

--- a/javascripts/discourse/initializers/dc-popup.js.es6
+++ b/javascripts/discourse/initializers/dc-popup.js.es6
@@ -20,7 +20,8 @@ export default {
             id: "dc-popup",
             hero: "We've got a new look! What do you think?",
             class: "hydrated",
-            url: "/"
+            url:
+              "https://community.debtcollective.org/t/user-experience-feedback-new-theme/4110"
           },
           `Noticed the new layout for the Debt Collective Community platform? Implementing this took a
               lot of time and effort and we want to make sure the new system works for you.

--- a/javascripts/discourse/initializers/dc-popup.js.es6
+++ b/javascripts/discourse/initializers/dc-popup.js.es6
@@ -1,4 +1,5 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
+import loadScript from "discourse/lib/load-script";
 
 let popupEnabled = false;
 
@@ -9,9 +10,8 @@ export default {
       api.onAppEvent("page:changed", () => {
         if (popupEnabled) return;
 
-        addScript(
-          "https://unpkg.com/@debtcollective/dc-popup-component@0.0.1/dist/popup-component/popup-component.js",
-          { defer: "", crossorigin: "anonymous" }
+        loadScript(
+          "https://unpkg.com/@debtcollective/dc-popup-component@0.0.1/dist/popup-component/popup-component.js"
         );
 
         addWebComponent(
@@ -43,16 +43,4 @@ function addWebComponent(tag, attrs, content) {
   component.textContent = content;
 
   document.body.appendChild(component);
-}
-
-function addScript(src, attrs) {
-  var script = document.createElement("script");
-
-  script.setAttribute("src", src);
-
-  Object.keys(attrs).forEach(key => {
-    script.setAttribute(key, attrs[key]);
-  });
-
-  document.body.appendChild(script);
 }

--- a/javascripts/discourse/initializers/dc-popup.js.es6
+++ b/javascripts/discourse/initializers/dc-popup.js.es6
@@ -1,0 +1,57 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+
+let popupEnabled = false;
+
+export default {
+  name: "dc-popup",
+  initialize() {
+    withPluginApi("0.8", api => {
+      api.onAppEvent("page:changed", () => {
+        if (popupEnabled) return;
+
+        addScript(
+          "https://unpkg.com/@debtcollective/dc-popup-component@0.0.1/dist/popup-component/popup-component.js",
+          { defer: "", crossorigin: "anonymous" }
+        );
+
+        addWebComponent(
+          "dc-popup",
+          {
+            id: "dc-popup",
+            hero: "We've got a new look! What do you think?",
+            class: "hydrated",
+            url: "/"
+          },
+          `Noticed the new layout for the Debt Collective Community platform? Implementing this took a
+              lot of time and effort and we want to make sure the new system works for you.
+              So, please let us know what is working well and what you may want to see done better!`
+        );
+
+        popupEnabled = true;
+      });
+    });
+  }
+};
+
+function addWebComponent(tag, attrs, content) {
+  var component = document.createElement(tag);
+
+  Object.keys(attrs).forEach(key => {
+    component.setAttribute(key, attrs[key]);
+  });
+  component.textContent = content;
+
+  document.body.appendChild(component);
+}
+
+function addScript(src, attrs) {
+  var script = document.createElement("script");
+
+  script.setAttribute("src", src);
+
+  Object.keys(attrs).forEach(key => {
+    script.setAttribute(key, attrs[key]);
+  });
+
+  document.body.appendChild(script);
+}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -19,6 +19,9 @@ en:
         You will be able to meet other people in your situation to share information and learn how to fight back together against creditors and collectors."
       others: 
         title: "Others categories"
+    popup:
+      title: "We've got a new look! What do you think?"
+      description: Noticed the new layout for the Debt Collective Community platform? Implementing this took a lot of time and effort and we want to make sure the new system works for you. So, please let us know what is working well and what you may want to see done better!
   notifications:
     tooltip:
       regular:

--- a/settings.yml
+++ b/settings.yml
@@ -16,3 +16,8 @@ show_current_efforts:
 logo_href:
   type: string
   default: ""
+popup_url:
+  description:
+    en: Define the URL that user will redirect to when click the popup (use full url from browser bar)
+  type: string
+  default: "https://community.debtcollective.org/t/user-experience-feedback-new-theme/4110"

--- a/settings.yml
+++ b/settings.yml
@@ -1,3 +1,6 @@
+extend_content_security_policy:
+  type: list
+  default: "script_src: https://unpkg.com/@debtcollective/"
 header_categories:
   type: list
   default: ""


### PR DESCRIPTION
**What:**
Render popup component within the community

**Why:**
https://app.asana.com/0/1168997577035609/1175421826877181

**How:**
Set a script on `page:changed` event from Discourse to load the popup distribution and append the component.

- [x] We need the proper URL for the popup before placing this live. 

**Note:** we have a flag that prevent to be doing this on every change but there is no other event from discourse that more or less fit our need.

**Media:**
https://www.loom.com/share/2b066bccf2184c248241100e8ec4f643