### PR TITLE
Avatar flair to render properly

### DIFF
--- a/javascripts/discourse/initializers/dc-post.js.es6
+++ b/javascripts/discourse/initializers/dc-post.js.es6
@@ -56,7 +56,7 @@ export default {
         html(attrs) {
           const html = this._super(attrs);
 
-          return h("div.dc-topic-avatar", html);
+          return h("div.dc-topic-avatar.user-image", html);
         }
       });
 

--- a/javascripts/discourse/templates/components/dc-categories-only.hbs
+++ b/javascripts/discourse/templates/components/dc-categories-only.hbs
@@ -6,7 +6,7 @@
     <p>
       {{{theme-i18n "dc.categories.currentEfforts.description"}}}
     </p>
-    <div class="dc-row">
+    <div class="dc-row mt-4">
       {{#each currentEfforts as |t|}}
         <div class="dc-col-sm-4">
           {{dc-topic-list-item-small topic=t}}
@@ -33,7 +33,7 @@
     <p>
       {{{theme-i18n "dc.categories.collectives.description"}}}
     </p>
-    <div class="dc-row">
+    <div class="dc-row mt-4">
       {{#each collectives as |c|}}
         <div class="dc-col-sm-6">
           {{dc-category-card category=c}}
@@ -47,7 +47,7 @@
     <h2 class="dc-heading mt-4 mb-2">
       {{theme-i18n "dc.categories.others.title"}}
     </h2>
-    <div class="dc-row">
+    <div class="dc-row mt-4">
       {{#each nonCollectives as |c|}}
         <div class="dc-col-sm-6">
           {{dc-category-card category=c}}

--- a/scss/widgets/post.scss
+++ b/scss/widgets/post.scss
@@ -1,5 +1,6 @@
 .dc-topic-avatar {
   text-align: center;
+  position: relative;
 }
 
 .dc-topic-body {


### PR DESCRIPTION
**What:**
Allow avatar flair to be visible

**Why:**
We need the distinction of staff users. 

**How:**
- While the component was being rendered properly Discourse expect it to be within certain conditions (a parent relative and with the class `.user-image`) to render properly

**Media:**
![image](https://user-images.githubusercontent.com/1425162/83329756-8e504300-a28b-11ea-93ea-21034a192e3e.png)

