### PR TITLE
Aesthetics improvements

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -18,6 +18,7 @@
 @import "connectors/hero";
 
 @import "templates/components/categories-only";
+@import "templates/components/cta-signup";
 @import "templates/components/d-navigation";
 @import "templates/components/dc-show-more";
 @import "templates/components/list-controls";

--- a/javascripts/discourse/templates/components/dc-category-card.hbs
+++ b/javascripts/discourse/templates/components/dc-category-card.hbs
@@ -15,7 +15,7 @@
   </div>
   <div class="dc-card__meta">
     <span class="material-icons">
-      comment
+      forum
     </span>
     <p class="m-0 ml-1 dc-text-light">
       {{category.totalTopicCount}}

--- a/scss/layout.scss
+++ b/scss/layout.scss
@@ -1,10 +1,10 @@
 body {
-  height: 100%;
+  // Usage of variables yield error on SCSS compiler
+  background: linear-gradient(180deg, #dbf8ff 0%, #fcfbf7 88.74%);
 
   // Up to some extend #main is the actual "body" of the page
+  &,
   #main {
-    // Usage of variables yield error on SCSS compiler
-    background: linear-gradient(180deg, #dbf8ff 0%, #fcfbf7 88.74%);
     min-height: 100%;
   }
 }

--- a/scss/layout.scss
+++ b/scss/layout.scss
@@ -1,6 +1,5 @@
 body {
-  // Usage of variables yield error on SCSS compiler
-  background: linear-gradient(180deg, #dbf8ff 0%, #fcfbf7 88.74%);
+  background: $background-gradient;
 
   // Up to some extend #main is the actual "body" of the page
   &,

--- a/scss/templates/components/cta-signup.scss
+++ b/scss/templates/components/cta-signup.scss
@@ -1,0 +1,4 @@
+.signup-cta {
+  width: auto;
+  max-width: 100%;
+}

--- a/scss/widgets/post.scss
+++ b/scss/widgets/post.scss
@@ -51,6 +51,17 @@
   }
 }
 
+.topic-post.moderator {
+  article {
+    background-color: dark-light-choose($highlight-low, $highlight-medium);
+  }
+
+  .regular > .cooked {
+    padding: 0;
+    background: none;
+  }
+}
+
 // Make extra emphasis to overcome guest styles
 .dc-topic-post.dc-topic-post {
   $padding-top: $spacer * 1.25;

--- a/scss/widgets/post.scss
+++ b/scss/widgets/post.scss
@@ -62,6 +62,10 @@
   }
 }
 
+.topic-post nav.post-controls .actions button.reply .d-icon {
+  color: #ffffff;
+}
+
 // Make extra emphasis to overcome guest styles
 .dc-topic-post.dc-topic-post {
   $padding-top: $spacer * 1.25;


### PR DESCRIPTION
**What:**
Address some known/unknown visual issues on the community

**Why:**
- Closes https://app.asana.com/0/1168997577035609/1177393609854433 fa389b9
- Closes https://app.asana.com/0/1168997577035609/1177708595506649 f6ff410

**Extras:**
We are fixing also:
- White icon on reply for mobile 1ce1248
- `signup-cta` to be as wider as the post stream 3f3b4b6
- Background of the site to always fill the entire page 807bc5a

**Media:**
https://cln.sh/QDN5x6 , https://cln.sh/GnvYTd , https://cln.sh/jsxMdj