### PR TITLE
feat(current-efforts): use pinned_globally instead of pinned

### DIFF
--- a/javascripts/discourse/components/categories-only.js.es6
+++ b/javascripts/discourse/components/categories-only.js.es6
@@ -16,6 +16,6 @@ export default Component.extend({
 
   @discourseComputed("topics")
   currentEfforts(topics) {
-    return (topics && topics.filter(topic => topic.pinned)) || [];
+    return (topics && topics.filter(topic => topic.pinned_globally)) || [];
   }
 });


### PR DESCRIPTION
**What:**  use `Topic.pinned_globally` instead of `Topic.pinned` to display current efforts

**Why:** Fixes https://app.asana.com/0/1168997577035609/1178339208108259

`Topic.pinned` is based on user preferences, while `Topic.pinned_globally` is always returns `true` until the topic is unpinned.

**How:**

- Change topic filter from `pinned` to `pinned_globally`