### PR TITLE
feat(preferences): hide control of default homepage

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -29,6 +29,7 @@
 @import "templates/composer";
 @import "templates/topic";
 @import "templates/user";
+@import "templates/preferences";
 
 @import "templates/list/dc-topic-author";
 @import "templates/list/dc-topic-card";

--- a/scss/templates/preferences.scss
+++ b/scss/templates/preferences.scss
@@ -1,0 +1,3 @@
+.user-preferences .control-group.home {
+  display: none;
+}


### PR DESCRIPTION
**What:**
Prevent users to have access to the homepage control

**Why:**
We want to force all users to have the same homepage

**How:**
Hide the control using CSS and then we will run a script to set the homepage id

**Media:**
![image](https://user-images.githubusercontent.com/1425162/86390032-94c14880-bc97-11ea-987f-293da1dbcd85.png)

