### PR TITLE
Categories custom links

### DIFF
--- a/javascripts/discourse/components/dc-categories-nav.js.es6
+++ b/javascripts/discourse/components/dc-categories-nav.js.es6
@@ -16,8 +16,9 @@ export default Component.extend({
   customLinks: computed(function() {
     const links = settings.header_categories_custom_links.split("|");
     return links.map(entry => {
-      const [text, url] = entry.split(",");
-      return { text: text.trim(), url: url.trim() };
+      const [text, url] = entry.split(",").map(str => str.trim());
+
+      return { text, url };
     });
   }),
 

--- a/javascripts/discourse/components/dc-categories-nav.js.es6
+++ b/javascripts/discourse/components/dc-categories-nav.js.es6
@@ -17,8 +17,9 @@ export default Component.extend({
     const links = settings.header_categories_custom_links.split("|");
     return links.map(entry => {
       const [text, url] = entry.split(",").map(str => str.trim());
+      const target = this._getAnchorTag(url);
 
-      return { text, url };
+      return { text, url, target };
     });
   }),
 
@@ -29,6 +30,13 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
+  },
+
+  _getAnchorTag(url) {
+    const isInternalURL = url.match(window.location.host);
+
+    // Avoid to set _self to allow ember route behave as expected
+    return isInternalURL ? undefined : "_blank";
   },
 
   _bindEvents() {

--- a/javascripts/discourse/components/dc-categories-nav.js.es6
+++ b/javascripts/discourse/components/dc-categories-nav.js.es6
@@ -13,6 +13,14 @@ export default Component.extend({
     return categories;
   }),
 
+  customLinks: computed(function() {
+    const links = settings.header_categories_custom_links.split("|");
+    return links.map(entry => {
+      const [text, url] = entry.split(",");
+      return { text: text.trim(), url: url.trim() };
+    });
+  }),
+
   didInsertElement() {
     this._super(...arguments);
     this._bindEvents();

--- a/javascripts/discourse/connectors/below-site-header/categories-nav.js.es6
+++ b/javascripts/discourse/connectors/below-site-header/categories-nav.js.es6
@@ -2,6 +2,9 @@ import Category from "discourse/models/category";
 
 export default {
   shouldRender(args, component) {
-    return settings.header_categories !== "";
+    return (
+      settings.header_categories !== "" ||
+      settings.header_categories_custom_links !== ""
+    );
   }
 };

--- a/javascripts/discourse/templates/components/dc-categories-nav.hbs
+++ b/javascripts/discourse/templates/components/dc-categories-nav.hbs
@@ -9,7 +9,7 @@
     {{/each}}
     {{#each customLinks as |link|}}
       <li>
-        <a href={{link.url}}>
+        <a href={{link.url}} target={{link.target}}>
           {{link.text}}
         </a>
       </li>

--- a/javascripts/discourse/templates/components/dc-categories-nav.hbs
+++ b/javascripts/discourse/templates/components/dc-categories-nav.hbs
@@ -7,5 +7,12 @@
         </a>
       </li>
     {{/each}}
+    {{#each customLinks as |link|}}
+      <li>
+        <a href={{link.url}}>
+          {{link.text}}
+        </a>
+      </li>
+    {{/each}}
   </ul>
 </div>

--- a/settings.yml
+++ b/settings.yml
@@ -7,6 +7,11 @@ header_categories:
   list_type: category
   description:
     en: A list of categories to render below the header. Defaults to off.
+header_categories_custom_links:
+  type: list
+  default: ""
+  description:
+    en: "A list of links to render alongside header categories with format: text,url"
 show_hero:
   type: bool
   default: true


### PR DESCRIPTION
**What:**
Add support for admins to render custom links on the categories nav

**Why:**
https://app.asana.com/0/1168997577035609/1181476354560133

**How:**
Enhance `dc-categories-nav` component with a new computed property `customLinks` that gets populated by admins.

**Media:**
https://www.loom.com/share/2700643cf6b445cea74452968e976424

