### PR TITLE
fix(header-navigation): restore dimensions from header navigation links

### DIFF
--- a/scss/connectors/categories-nav.scss
+++ b/scss/connectors/categories-nav.scss
@@ -1,6 +1,6 @@
 $dc-header-box-shadow: "0 0.125rem 0.25rem -0.0625rem rgba(0, 0, 0, 0.25)";
 $dc-categories-border: "0.0625rem solid #ebe7dc";
-$dc-categories-height: 3rem;
+$dc-categories-height: 4rem;
 
 #main-outlet {
   // We need to increase the separation between content and header due to categories-nav

--- a/scss/connectors/categories-nav.scss
+++ b/scss/connectors/categories-nav.scss
@@ -1,10 +1,11 @@
 $dc-header-box-shadow: "0 0.125rem 0.25rem -0.0625rem rgba(0, 0, 0, 0.25)";
 $dc-categories-border: "0.0625rem solid #ebe7dc";
-$dc-categories-height: 4rem;
+$dc-categories-height-base: 4rem;
+$dc-categories-height-base-sm: $dc-categories-height-base * 0.875;
 
 #main-outlet {
   // We need to increase the separation between content and header due to categories-nav
-  padding-top: $header-height + $dc-categories-height + $spacer;
+  padding-top: $header-height + $dc-categories-height-base + $spacer;
 
   @if $header-categories == "" {
     padding-top: $header-height + $spacer;
@@ -68,9 +69,9 @@ $dc-categories-height: 4rem;
     align-items: center;
     border-left: unquote($dc-categories-border);
     display: flex;
-    font-size: $font-size-xs;
+    font-size: $font-size-sm;
     font-weight: $font-weight-bold;
-    height: $dc-categories-height * 0.75;
+    height: $dc-categories-height-base-sm;
     padding: 0 $grid-gutter-width/2;
     text-transform: uppercase;
     white-space: nowrap;
@@ -80,7 +81,8 @@ $dc-categories-height: 4rem;
     }
 
     @include media-breakpoint-up(lg) {
-      height: $dc-categories-height;
+      font-size: $font-size-base;
+      height: $dc-categories-height-base;
     }
   }
 }


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1168997577035609/1183039448302281/f

**What:**
Restore the dimension of the header navigation links

**Why:**
On a previous change, the header dimensions were changed and turned smaller

**How:**
By rolling back the dimensions as they were before

**Media**

Video: https://www.loom.com/share/11067f458179466289baceff8569b676

Before:
![image](https://user-images.githubusercontent.com/20747535/86642769-c9881500-bfa1-11ea-9581-6d71cf1a2992.png)

After:
![image](https://user-images.githubusercontent.com/20747535/86642713-bc6b2600-bfa1-11ea-9608-4799d2e25fc8.png)