### PR TITLE
fix(categories-dropdown): use all space available for categories items

### DIFF
--- a/scss/templates/components/list-controls.scss
+++ b/scss/templates/components/list-controls.scss
@@ -52,4 +52,8 @@ body {
     margin-top: 0;
     margin-bottom: 0;
   }
+
+  .select-kit-collection .select-kit-row.category-row {
+    max-width: 100%;
+  }
 }


### PR DESCRIPTION
**What:**
Enable categories list items to fill all available space in dropdown

**Why:**
Dropdown items should take the space available in the dropdown, this is the way it looks now
![image](https://user-images.githubusercontent.com/20747535/86516222-69983f80-bde4-11ea-97fd-94727d5ce738.png)

**How:**
The items were having a `max-width` of `345px`, that is the reason they were not filling all the space, by setting the max-width as 100% now the items look like this

![image](https://user-images.githubusercontent.com/20747535/86516238-8e8cb280-bde4-11ea-8a4c-c5545028701a.png)

