### PR TITLE
fix(categories-nav): validate unexpected formats before render

### DIFF
--- a/javascripts/discourse/components/dc-categories-nav.js.es6
+++ b/javascripts/discourse/components/dc-categories-nav.js.es6
@@ -35,7 +35,7 @@ export default Component.extend({
     });
 
     // return only those items that were valid
-    return linkItems.filter(item => item !== null);
+    return linkItems.filter(Boolean);
   }),
 
   didInsertElement() {

--- a/javascripts/discourse/components/dc-categories-nav.js.es6
+++ b/javascripts/discourse/components/dc-categories-nav.js.es6
@@ -15,12 +15,27 @@ export default Component.extend({
 
   customLinks: computed(function() {
     const links = settings.header_categories_custom_links.split("|");
-    return links.map(entry => {
-      const [text, url] = entry.split(",").map(str => str.trim());
+
+    const linkItems = links.map(entry => {
+      // Invalidate emty entries
+      if (!entry.trim()) return null;
+
+      const parsedEntry = entry.split(",");
+      // Invalidate entries that doesn't split into expected items to avoid unexpected output
+      if (parsedEntry.length !== 2) return null;
+
+      const [text, url] = parsedEntry.map(str => str.trim());
+
+      // Invalidate empty text or empty url entries
+      if (!text || !url) return null;
+
       const target = this._getAnchorTag(url);
 
       return { text, url, target };
     });
+
+    // return only those items that were valid
+    return linkItems.filter(item => item !== null);
   }),
 
   didInsertElement() {


### PR DESCRIPTION
**What:**
Add checks to avoid empty values or unexpected formats

**Why:**
Issue after deploy https://github.com/debtcollective/discourse-debtcollective-theme/pull/68 with empty URL values makes community to crash

**How:**
Add checks before try to render or apply further parsing process of given format.

**Media:**
https://www.loom.com/share/d21270ad29794669acf1a0c2903cffdb