### PR TITLE
Notifications improvements

### DIFF
--- a/javascripts/discourse/components/dc-topic-card-content.js.es6
+++ b/javascripts/discourse/components/dc-topic-card-content.js.es6
@@ -3,5 +3,15 @@ import Component from "@ember/component";
 
 export default Component.extend({
   tagName: "div",
-  classNames: ["dc-topic-card-content", "h-100"]
+  classNames: ["dc-topic-card-content", "h-100"],
+  classNameBindings: ["isUnread:is-unread:already-seen"],
+
+  didInsertElement() {
+    this._bindClasses();
+  },
+
+  _bindClasses() {
+    const isUnread = this.topic.totalUnread > 0 || this.topic.unseen;
+    this.set("isUnread", isUnread);
+  }
 });

--- a/javascripts/discourse/initializers/dc-header.js.es6
+++ b/javascripts/discourse/initializers/dc-header.js.es6
@@ -95,23 +95,23 @@ export default {
           );
 
           // add messages icon with count
-          const unreadPMs = user.get("unread_private_messages");
+          const unreadPriority = user.get("unread_high_priority_notifications");
 
           html.push(
             h(
               "li.header-dropdown-toggle#inbox",
               h("a", { href: `${user.path}/messages` }, [
                 h("div.icon.btn-flat.material-icons", "email"),
-                unreadPMs
+                unreadPriority
                   ? h(
                       "span.badge-notification.unread-private-messages",
                       {
                         title: I18n.t(
-                          themePrefix("notifications.tooltip.message"),
-                          { count: unreadPMs }
+                          themePrefix("notifications.tooltip.high_priority"),
+                          { count: unreadPriority }
                         )
                       },
-                      unreadPMs
+                      unreadPriority
                     )
                   : null
               ])

--- a/javascripts/discourse/templates/components/dc-topic-card-content.hbs
+++ b/javascripts/discourse/templates/components/dc-topic-card-content.hbs
@@ -1,4 +1,9 @@
 <div class="dc-row h-100">
+  {{topic-post-badges
+    newPosts=topic.totalUnread
+    unseen=topic.unseen
+    url=topic.lastUnreadUrl
+  }}
   <div class="dc-col avatar-col">
     <div class="mr-2">
       {{raw "list/dc-topic-author" posters=topic.featuredUsers}}

--- a/scss/button.scss
+++ b/scss/button.scss
@@ -25,7 +25,8 @@
 
 .btn-action,
 .btn-primary,
-.widget-button.reply {
+.widget-button.reply,
+.dismiss-notifications.btn {
   @extend %action-button;
 }
 

--- a/scss/templates/list/dc-topic-card.scss
+++ b/scss/templates/list/dc-topic-card.scss
@@ -30,6 +30,12 @@
   }
 }
 
+.dc-topic-card-content .topic-post-badges {
+  position: absolute;
+  top: $grid-gutter-width / 4;
+  right: $grid-gutter-width / 4;
+}
+
 .has-excerpt .dc-topic.dc-card {
   .dc-card__text {
     margin-top: $spacer * 0.75;

--- a/scss/templates/user.scss
+++ b/scss/templates/user.scss
@@ -5,3 +5,7 @@
 .user-content-wrapper .show-mores {
   position: relative;
 }
+
+.user-messages-page .dc-topic-card-content.already-seen {
+  opacity: 0.5;
+}


### PR DESCRIPTION
**What:**
Add fixes to allow notifications behaves similar to core theme

**Why:**
Users have issues to understand how to clear notifications
re https://app.asana.com/0/1168997577035609/1182066742206561

**How:**
- [x] [Make notifications realtime](https://www.loom.com/share/925eb0cb777243c48f87c54d531ec97b)
- [x] [Dismiss notifications button _(single click dismiss all)_](https://www.loom.com/share/1d21f5bd98ff4b59a758191308a86375)
- [x] [Visual feedback on topics that requires attention _(causes of notification badge)_](https://www.loom.com/share/4098ab1d933441b38f2ed800ae06b666)

> If you need more information go to the asana ticket where I also add couple videos showcasing the core behaviour and the previous wrong behaviour of the theme