### PR TITLE
feat(discourse-theme): script to update discourse theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,7 @@
       "pre-commit": "lint-staged"
     }
   },
-  "dependencies": {}
+  "dependencies": {
+    "node-fetch": "^2.6.0"
+  }
 }

--- a/scripts/update-theme.js
+++ b/scripts/update-theme.js
@@ -1,0 +1,27 @@
+const fetch = require("node-fetch");
+
+function updateTheme(themeId, baseUrl, apiKey, apiUsername) {
+  fetch(`${baseUrl}/admin/themes/${themeId}`, {
+    headers: {
+      "content-type": "application/json",
+      "Api-Key": `${apiKey}`,
+      "Api-Username": `${apiUsername}`
+    },
+    body: JSON.stringify({
+      theme: {
+        remote_update: true
+      }
+    }),
+    method: "PUT"
+  })
+    .then(response => response.json())
+    .then(() => console.log("Theme updated successfully 🚀"))
+    .catch(error => console.error(error));
+}
+
+updateTheme(
+  process.env.DISCOURSE_THEME_ID,
+  process.env.DISCOURSE_APP_BASE_URL,
+  process.env.DISCOURSE_API_KEY,
+  process.env.DISCOURSE_API_USERNAME
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2901,6 +2901,11 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+node-fetch@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
 node-releases@^1.1.44:
   version "1.1.46"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.46.tgz#6b262afef1bdc9a950a96df2e77e0d2290f484bf"


### PR DESCRIPTION
**What:**
I created a script that will update the discourse theme in our CI, this could be either our development or production theme.

**Why:**
Every time that we added changes to discourse theme it was necessary to update the theme manually
https://app.asana.com/0/1168997577035609/1183011647269227

**How:**
By requesting discourse API to update the theme, we will integrate this script into our CI process, in this way, anytime we add a new change and merge either to development or production, the theme will have the latest changes.

Media: 
[Update a theme manually](https://www.loom.com/share/51f86e3935fe47108a99dddca62f48d2)
[Update a theme with the script](https://www.loom.com/share/b1bab9fe489648709598890ab26ec82b)