### PR TITLE
Create circleCI configuration to run update-theme script when merging to develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+version: 2.1
+jobs:
+  update_theme:
+    docker:
+      - image: circleci/node:12.18.1
+    steps:
+      - checkout
+      - run:
+          name: install node fetch
+          command: npm install node-fetch
+      - run:
+          name: Update community theme
+          command: node scripts/update-theme.js
+
+workflows:
+  version: 2
+  pipeline:
+    jobs:
+      - update_theme:
+          filters:
+            branches:
+              only: develop

--- a/scripts/update-theme.js
+++ b/scripts/update-theme.js
@@ -16,7 +16,10 @@ function updateTheme(themeId, baseUrl, apiKey, apiUsername) {
   })
     .then(response => response.json())
     .then(() => console.log("Theme updated successfully 🚀"))
-    .catch(error => console.error(error));
+    .catch(error => {
+      console.error(error);
+      process.exit(1);
+    });
 }
 
 updateTheme(


### PR DESCRIPTION
**What:**
Create circleCI configuration to run `update-theme` script when merging to develop

**Why:**
To enable: https://app.asana.com/0/1159164196409129/1183011647269227/f

**How:**
I created a job that will use a node docker image and run the `update-theme` script. Something to taking in count:

Notes:
We need to setup some env variables at circle ci context in order for the script to work
```bash
- DISCOURSE_THEME_ID
- DISCOURSE_APP_BASE_URL
- DISCOURSE_API_KEY
- DISCOURSE_API_USERNAME
```

