### PR TITLE
fix(current-efforts): pull using 'current-efforts' tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ If you want to know more about themes, themes component, widgets and other custo
 
 This theme expect the community to have set **Categories only** as a homepage, you can achieve that by running setup wizard again visiting `http://localhost:3000/wizard` (for local discourse)
 
+### Current Efforts
+
+The current efforts section in the Home Page pulls from the `current-efforts` tag. This tag is only be avaiable for staff to use.
+
 ## Development
 
 There are different ways to approach this, using a local setup of Discourse and using the [Theme creator](https://theme-creator.discourse.org/) which doesn't need much further setup for you to start the development process but it does need **internet connection to develop**. Check [Beginners’ guide to using Theme Creator and Theme CLI to start building a Discourse theme](https://meta.discourse.org/t/beginners-guide-to-using-theme-creator-and-theme-cli-to-start-building-a-discourse-theme/108444), after complete you should be ready to start.

--- a/javascripts/discourse/components/categories-only.js.es6
+++ b/javascripts/discourse/components/categories-only.js.es6
@@ -1,8 +1,12 @@
 import discourseComputed from "discourse-common/utils/decorators";
 import Component from "@ember/component";
+import Topic from "discourse/models/topic";
+import { ajax } from "discourse/lib/ajax";
+import { computed } from "@ember/object";
 
 export default Component.extend({
   tagName: "div",
+  currentEfforts: [],
 
   @discourseComputed("categories")
   collectives(categories) {
@@ -14,8 +18,27 @@ export default Component.extend({
     return categories.filter(category => !category.tdc_is_collective);
   },
 
-  @discourseComputed("topics")
-  currentEfforts(topics) {
-    return (topics && topics.filter(topic => topic.pinned_globally)) || [];
+  didInsertElement() {
+    this._fetchCurrentEfforts();
+  },
+
+  _fetchCurrentEfforts() {
+    ajax("/tags/current-efforts.json").then(results => {
+      const currentEfforts = [];
+      const topics = results.topic_list.topics || [];
+      const users = results.users;
+
+      topics.forEach(function(topic) {
+        topic.posters.forEach(function(poster) {
+          poster.user = $.grep(users, function(user) {
+            return user.id == poster.user_id;
+          })[0];
+        });
+
+        currentEfforts.push(Topic.create(topic));
+      });
+
+      this.set("currentEfforts", currentEfforts);
+    });
   }
 });

--- a/javascripts/discourse/initializers/dc-popup.js.es6
+++ b/javascripts/discourse/initializers/dc-popup.js.es6
@@ -11,7 +11,7 @@ export default {
         if (popupEnabled) return;
 
         loadScript(
-          "https://unpkg.com/@debtcollective/dc-popup-component@0.0.1/dist/popup-component/popup-component.js"
+          "https://unpkg.com/@debtcollective/dc-popup-component@latest/dist/popup-component/popup-component.js"
         );
 
         addWebComponent(

--- a/javascripts/discourse/templates/components/dc-categories-only.hbs
+++ b/javascripts/discourse/templates/components/dc-categories-only.hbs
@@ -1,5 +1,5 @@
 {{#if themeSettings.show_current_efforts}}
-  {{#if currentEfforts}}
+  {{#if currentEfforts.length}}
     <div class="dc-categories-container">
       <h2 class="dc-heading mt-4 mb-2">
         {{theme-i18n "dc.categories.currentEfforts.title"}}


### PR DESCRIPTION
**What:** Fix current efforts section, by pulling topics with the `current-efforts` tag instead of expecting Discourse to provide those topics on the first load.

**Why:** Currently, the **Current Efforts** section doesn't work as we expect, because Discourse has a specific behavior around `global_pinned` topics where not all the pinned topics are fetched on the first load. To fix this, we are creating a new tag only for staff to use called `current-efforts`. Now if we want to display a topic in the current-efforts section, is just a matter of tagging that topic.

Fixes https://app.asana.com/0/1168997577035609/1178339208108259

**How:**

- Request current efforts topics after load doing an ajax call to `tags/current-efforts.json` endpoint.