### PR TITLE
fix(circle-ci): set correct branch to trigger job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,4 +19,4 @@ workflows:
       - update_theme:
           filters:
             branches:
-              only: develop
+              only: development


### PR DESCRIPTION
**What:**
Update Circle CI configuration file to run the `update_theme` job when merging into development

**Why:**
To fix #77 

**How:**
By setting `development` as the correct branch to run the ci job
