### PR TITLE
fix(composer-fields): make all items of the same size

### DIFF
--- a/scss/templates/composer.scss
+++ b/scss/templates/composer.scss
@@ -17,6 +17,18 @@
   margin-bottom: 0;
 }
 
+#reply-control .title-and-category {
+  > * {
+    margin-bottom: 0.5rem !important;
+    // For the sake of simplicity adjust to the known height of surround inputs
+    height: 2.3125rem !important;
+  }
+
+  .select-kit.combo-box.mini-tag-chooser .select-kit-header {
+    height: 100% !important;
+  }
+}
+
 #reply-control .name {
   display: inherit;
 }
@@ -27,6 +39,7 @@
   margin-bottom: $spacer/2;
 }
 
+.composer-fields .composer-controls-location .location-label button.no-text,
 .composer-fields .composer-controls-event .event-label button.no-text {
   @extend %composer-input-controls;
   padding: 0;


### PR DESCRIPTION
**What:**
Apply the same size and border style to all elements that belong to input controls.

**Why:**
To fix: https://app.asana.com/0/1159164196409156/1185931631318929/f

**How:**
- Apply the same style rules to location controls that were being applied to event controls.
- Apply the same size for all elements at the first level beneath `title-and-category` section.

Media:

**Before**
![image](https://user-images.githubusercontent.com/20747535/88446118-013dec00-cded-11ea-9a0d-9e2cdb08cd74.png)

**After**
![image](https://user-images.githubusercontent.com/20747535/88446306-8970c100-cdee-11ea-9698-a580002464e6.png)




