### PR TITLE
fix(message-composer): avoid rendering twice original message

### DIFF
--- a/scss/widgets/embedded-posts.scss
+++ b/scss/widgets/embedded-posts.scss
@@ -17,7 +17,7 @@
   }
 }
 
-section.embedded-posts.top.topic-body.offset2:not(.dc-component) {
+section.embedded-posts.top.topic-body:not(.dc-component) {
   display: none;
 }
 


### PR DESCRIPTION
**What:**
Avoid rendering twice the original message

**Why:**
When replying to a message, the original message was being rendered twice on the message composer

**How:**
By adding a `display: none` to the content that was being duplicated

Media:
**Before:**
![image](https://user-images.githubusercontent.com/20747535/88461145-a3e68100-ce66-11ea-89a2-5e78b9b16fa1.png)

**After:**
![image](https://user-images.githubusercontent.com/20747535/88461139-9a5d1900-ce66-11ea-91dc-593cb44c6123.png)

