### PR TITLE
fix(create-account): the logic behind username input was out dated

### DIFF
--- a/javascripts/discourse/templates/modal/create-account.hbs
+++ b/javascripts/discourse/templates/modal/create-account.hbs
@@ -59,14 +59,18 @@
                     </label>
                   </td>
                 </tr>
-                {{#if usernameRequired}}
-                  <tr class="input">
-                    <td class="label">
-                      <label for="new-account-username">
-                        {{i18n "user.username.title"}}
-                      </label>
-                    </td>
-                    <td>
+                <tr class="input">
+                  <td class="label">
+                    <label for="new-account-username">
+                      {{i18n "user.username.title"}}
+                    </label>
+                  </td>
+                  <td>
+                    {{#if usernameDisabled}}
+                      <span class="value">
+                        {{accountUsername}}
+                      </span>
+                    {{else}}
                       {{input
                         value=accountUsername
                         id="new-account-username"
@@ -74,21 +78,21 @@
                         maxlength=maxUsernameLength
                         autocomplete="discourse"
                       }}
-                    </td>
-                  </tr>
-                  <tr class="instructions">
-                    <td></td>
-                    {{input-tip
-                      validation=usernameValidation
-                      id="username-validation"
-                    }}
-                    <td>
-                      <label>
-                        {{i18n "user.username.instructions"}}
-                      </label>
-                    </td>
-                  </tr>
-                {{/if}}
+                    {{/if}}
+                  </td>
+                </tr>
+                <tr class="instructions">
+                  <td></td>
+                  {{input-tip
+                    validation=usernameValidation
+                    id="username-validation"
+                  }}
+                  <td>
+                    <label>
+                      {{i18n "user.username.instructions"}}
+                    </label>
+                  </td>
+                </tr>
                 {{#if fullnameRequired}}
                   <tr class="input">
                     <td class="label">


### PR DESCRIPTION
**What:**
Restore username input on login so user can create an account

**Why:**
there has been changes on the core code for Discourse that need to be addressed to display form as
expected. The changes that has been done so far can be found at https://github.com/discourse/discourse/commits/master/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs

related to https://app.asana.com/0/1168997577035609/1187007774305284

[Breaking changes reference](https://user-images.githubusercontent.com/1425162/89052084-782b3580-d355-11ea-91ea-974eb4676e38.png)

**How:**
Use the same logic than Discourse core to render the username field

**Media:**
![image](https://user-images.githubusercontent.com/1425162/89052299-cb04ed00-d355-11ea-850a-af0ed64f3d60.png)
