### PR TITLE
feat(user-profile-summary): update styles to match design

### DIFF
--- a/javascripts/discourse/templates/user/summary.hbs
+++ b/javascripts/discourse/templates/user/summary.hbs
@@ -1,0 +1,94 @@
+{{#d-section pageClass="user-summary" tagName=""}}
+<div class="user-content">
+  {{#if model.can_see_summary_stats}}
+  <div class="top-section stats-section">
+    <h3 class="stats-title">{{i18n "user.summary.stats"}}</h3>
+    <ul>
+      <li>
+        {{user-stat value=model.days_visited label="user.summary.days_visited"}}
+      </li>
+      <li>
+        {{user-stat value=timeRead label="user.summary.time_read" type="string"}}
+      </li>
+      {{#if showRecentTimeRead}}
+      <li>
+        {{user-stat value=recentTimeRead label="user.summary.recent_time_read" type="string"}}
+      </li>
+      {{/if}}
+      <li>
+        {{user-stat value=model.topics_entered label="user.summary.topics_entered"}}
+      </li>
+      <li>
+        {{user-stat value=model.posts_read_count label="user.summary.posts_read"}}
+      </li>
+      <li class="linked-stat">
+        {{#link-to "userActivity.likesGiven"}}
+        {{user-stat value=model.likes_given icon="heart" label="user.summary.likes_given"}}
+        {{/link-to}}
+      </li>
+      {{#if model.bookmark_count}}
+      <li class="linked-stat">
+        {{#link-to "userActivity.bookmarks"}}
+        {{user-stat value=model.bookmark_count label="user.summary.bookmark_count"}}
+        {{/link-to}}
+      </li>
+      {{/if}}
+      <li class="linked-stat">
+        {{#link-to "userActivity.topics"}}
+        {{user-stat value=model.topic_count label="user.summary.topic_count"}}
+        {{/link-to}}
+      </li>
+      <li class="linked-stat">
+        {{#link-to "userActivity.replies"}}
+        {{user-stat value=model.post_count label="user.summary.post_count"}}
+        {{/link-to}}
+      </li>
+      <li>
+        {{user-stat value=model.likes_received icon="heart" label="user.summary.likes_received"}}
+      </li>
+      {{plugin-outlet name="user-summary-stat" tagName="" connectorTagName="li" args=(hash model=model)}}
+    </ul>
+  </div>
+  {{/if}}
+
+  <div class="top-section most-liked-section">
+    {{#user-summary-section title="most_liked_by" class="summary-user-list liked-by-section"}}
+    {{#user-summary-users-list none="no_likes" users=model.most_liked_by_users as |user|}}
+    {{user-summary-user user=user icon="heart" countClass="likes"}}
+    {{/user-summary-users-list}}
+    {{/user-summary-section}}
+
+    {{#user-summary-section title="most_liked_users" class="summary-user-list liked-section"}}
+    {{#user-summary-users-list none="no_likes" users=model.most_liked_users as |user|}}
+    {{user-summary-user user=user icon="heart" countClass="likes"}}
+    {{/user-summary-users-list}}
+    {{/user-summary-section}}
+
+    {{#user-summary-section title="most_replied_to_users" class="summary-user-list replied-section"}}
+    {{#user-summary-users-list none="no_replies" users=model.most_replied_to_users as |user|}}
+    {{user-summary-user user=user icon="reply" countClass="replies"}}
+    {{/user-summary-users-list}}
+    {{/user-summary-section}}
+  </div>
+
+  <div class="top-section top-replies-section">
+    {{#user-summary-section title="top_replies" class="replies-section"}}
+    {{#user-summary-topics-list type="replies" items=model.replies user=user as |reply|}}
+    {{user-summary-topic
+            topic=reply.topic
+            likes=reply.like_count
+            url=reply.url}}
+    {{/user-summary-topics-list}}
+    {{/user-summary-section}}
+
+    {{#user-summary-section title="top_topics" class="topics-section"}}
+    {{#user-summary-topics-list type="topics" items=model.topics user=user as |topic|}}
+    {{user-summary-topic
+            topic=topic
+            likes=topic.like_count
+            url=topic.url}}
+    {{/user-summary-topics-list}}
+    {{/user-summary-section}}
+  </div>
+</div>
+{{/d-section}}

--- a/scss/templates/user.scss
+++ b/scss/templates/user.scss
@@ -1,5 +1,23 @@
 .user-content {
   background: transparent;
+
+  .d-icon-heart {
+    color: $gray-100;
+  }
+
+  .top-section {
+    margin-bottom: 2rem;
+  }
+
+  @include media-breakpoint-up(sm) {
+    .top-section {
+      margin-bottom: 3rem;
+
+      &:first-child {
+        margin-bottom: 1rem;
+      }
+    }
+  }
 }
 
 .user-content-wrapper .show-mores {
@@ -22,74 +40,6 @@
     &:hover {
       color: $blue !important;
       border-bottom-color: $blue !important;
-    }
-  }
-}
-
-.stats-section {
-  .stats-title {
-    display: none;
-  }
-
-  ul {
-    display: flex;
-    flex-wrap: wrap;
-  }
-
-  li,
-  .linked-stat {
-    margin: 0;
-    padding: 0;
-    margin: 0 1.5rem 1.5rem 0;
-
-    > a {
-      padding: 0 !important;
-    }
-  }
-
-  .user-stat {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-direction: column;
-    width: 10rem;
-    height: 7.5rem;
-    background-color: $blue;
-    border-radius: 0.25rem;
-
-    .number,
-    .label,
-    .value {
-      color: $white;
-    }
-
-    .number,
-    .value {
-      font-size: 2.25rem;
-    }
-
-    .label {
-      font-size: 0.75rem;
-      font-weight: bold;
-      text-transform: uppercase;
-      margin-top: 0.75rem;
-    }
-  }
-
-  @include media-breakpoint-down(sm) {
-    ul {
-      display: grid;
-      grid-template-columns: repeat(2, 1fr);
-      grid-gap: 0.75rem;
-    }
-
-    li,
-    .linked-stat {
-      margin: 0;
-    }
-
-    .user-stat {
-      width: 100%;
     }
   }
 }
@@ -195,6 +145,191 @@
   @include media-breakpoint-up(sm) {
     .primary .primary-textual {
       padding-left: 7.75rem;
+    }
+  }
+}
+
+.stats-section {
+  .stats-title {
+    display: none;
+  }
+
+  ul {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  li,
+  .linked-stat {
+    margin: 0;
+    padding: 0;
+    margin: 0 1.5rem 1.5rem 0;
+
+    > a {
+      padding: 0 !important;
+    }
+  }
+
+  .user-stat {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    width: 10rem;
+    height: 7.5rem;
+    background-color: $blue;
+    border-radius: 0.25rem;
+
+    .number,
+    .label,
+    .value {
+      color: $white;
+      font-style: normal;
+      font-weight: normal;
+    }
+
+    .number,
+    .value {
+      font-size: 2.25rem;
+      font-family: "Roboto", $font-family-sans-serif;
+    }
+
+    .label {
+      font-size: 0.75rem;
+      font-weight: bold;
+      text-transform: uppercase;
+      margin-top: 0.75rem;
+
+      .d-icon-heart {
+        display: none;
+      }
+    }
+  }
+
+  @include media-breakpoint-down(sm) {
+    ul {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      grid-gap: 0.75rem;
+    }
+
+    li,
+    .linked-stat {
+      margin: 0;
+    }
+
+    .user-stat {
+      width: 100%;
+    }
+  }
+}
+
+.most-liked-section,
+.top-replies-section {
+  display: grid;
+  grid-gap: 2.4375rem;
+  grid-template-columns: 1fr;
+
+  .stats-title {
+    text-transform: none;
+    font-style: normal;
+    font-weight: bold;
+    font-size: 1.125rem;
+    line-height: 1.375rem;
+    color: $gray-100;
+  }
+
+  .top-sub-section,
+  .summary-user-list {
+    width: 100%;
+    margin-bottom: 0;
+
+    > div > ul > li,
+    > ul > li {
+      height: auto;
+      border-bottom: 0.0625rem solid $gray-ligth;
+      border-left: none;
+
+      &:not(:last-child) {
+        margin: 0 0 0.78125rem;
+      }
+
+      &:last-child {
+        margin: 0;
+      }
+    }
+  }
+
+  &::before,
+  &::after {
+    display: none;
+  }
+
+  @include media-breakpoint-up(sm) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.most-liked-section .summary-user-list {
+  > div > ul > li {
+    .user-info {
+      margin-bottom: 0;
+
+      .user-image {
+        width: 2.5rem;
+        height: 2.5rem;
+
+        .user-image-inner a img {
+          width: 100%;
+          height: 100%;
+        }
+      }
+
+      .user-detail {
+        display: flex;
+        float: none;
+        height: 2.5rem;
+        justify-content: space-between;
+        align-items: center;
+        padding: 0;
+        width: 80%;
+
+        .name {
+          display: none;
+        }
+      }
+    }
+  }
+}
+
+.top-replies-section {
+  .stats-title {
+    margin-bottom: 1.5rem;
+  }
+
+  .top-sub-section ul li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    min-height: 3.25rem;
+    margin-bottom: 0.8rem;
+
+    a {
+      order: 1;
+      max-width: 85%;
+      font-style: normal;
+      font-weight: bold;
+      font-size: 0.875rem;
+      line-height: 1.0625rem;
+      color: $gray-100;
+    }
+
+    .topic-info {
+      order: 2;
+    }
+
+    br {
+      display: none;
     }
   }
 }

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -2,6 +2,7 @@
 $beige: #fbfbfb;
 $blue: #03a9f4;
 $gray: #2b2b2b;
+$gray-100: #424242;
 $gray-ligth: #bdbdbd;
 $green: #2dcbad;
 $purple: #dac4f5;


### PR DESCRIPTION
**What:**
- Update styles on user summary to match the design

**Why:**
To address: https://app.asana.com/0/1159164196409129/1186341795801831/f subtask 4

**How:**
- Overwrite summary.hbs to customize the order of summary stats
- Overwrite default styles from discourse to use our own design

**Notes**
- Top categories and top badges were not included in the Figma design, so, I did remove them from the UI. If they need to be displayed let me know to add them.

![image](https://user-images.githubusercontent.com/20747535/89594343-2718b700-d817-11ea-8d4d-806dc0cf5ec5.png)

Media:
https://www.loom.com/share/434732bf989a4218b7a2008840ff8239
![image](https://user-images.githubusercontent.com/20747535/89594456-76f77e00-d817-11ea-8109-8517de2b9d42.png)
![image](https://user-images.githubusercontent.com/20747535/89594441-69da8f00-d817-11ea-923f-daaf7c8e0b4c.png)

