### PR TITLE
fix(user-profile): prevent scrolling on profile nav

### DIFF
--- a/scss/templates/user.scss
+++ b/scss/templates/user.scss
@@ -29,7 +29,7 @@
 }
 
 .user-nav {
-  overflow-x: scroll;
+  overflow: hidden;
   min-height: 3rem;
 
   li > a {


### PR DESCRIPTION
**What:**
Prevent scrolling on the navbar at user profile

**Why:**
To fix: #90 

**How:**
- Setting navbar overflow as hidden