### PR TITLE
fix(private-messages): build category only when attrs has category value

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,20 +89,6 @@ Create an API key for an admin user and fill the `cypress.env.json` with the use
 yarn run test:e2e:dev
 ```
 
-### Testing
-
-Due to limitations of discourse technology we choose to drive our code using [crypress.io](https://www.cypress.io/) in order to make the test run you need to:
-
-```bash
-cp cypress.sample.json cypress.env.json
-```
-
-Create an API key for an admin user and fill the `cypress.env.json` with the username and the api key as the template suggests
-
-```bash
-yarn run test:e2e:dev
-```
-
 ## Customization
 
 This theme expect the community to have set **Categories only** as a homepage, you can achieve that by running setup wizard again visiting `http://localhost:3000/wizard` (for local discourse)

--- a/javascripts/discourse/widgets/dc-topic-title.js.es6
+++ b/javascripts/discourse/widgets/dc-topic-title.js.es6
@@ -45,7 +45,17 @@ export default createWidget("dc-topic-title", {
   },
 
   buildTopicInfo(attrs) {
-    return [this.buildCategory(attrs), this.buildTopicTags(attrs)];
+    const topicInfo = [];
+
+    if (attrs.category) {
+      topicInfo.push(this.buildCategory(attrs));
+    }
+
+    if (attrs.tags) {
+      topicInfo.push(this.buildTopicTags(attrs));
+    }
+
+    return topicInfo;
   },
 
   html(attrs, state) {


### PR DESCRIPTION
**What:**
Build category data only when `attrs.category` has value

**Why:**
To fix: https://app.asana.com/0/1159164196409156/1188957743196805/f

**How:**
- Add conditionals to compute the data


Notes:
- Remove duplicated section `testing` from README.md