### PR TITLE
feat(header): integrate the dc-dropdown to display the take action links

### DIFF
--- a/javascripts/discourse/initializers/dc-header.js.es6
+++ b/javascripts/discourse/initializers/dc-header.js.es6
@@ -1,4 +1,5 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
+import loadScript from "discourse/lib/load-script";
 import { h } from "virtual-dom";
 
 export default {
@@ -19,6 +20,13 @@ export default {
           $(searchButton)
             .addClass("material-icons")
             .html("search");
+        },
+        didInsertElement() {
+          this._super();
+          // TODO: whenever the dc-dropdown-component is available use that instead
+          loadScript(
+            "https://unpkg.com/@debtcollective/dc-header-component@1.5.0/dist/header/header.js"
+          );
         },
         afterRender() {
           this._super();
@@ -160,7 +168,32 @@ export default {
           return h("a.dc-header-link", { href, target }, text);
         });
 
-        return helper.h("nav.dc-custom-headers-links.d-none.d-md-block", links);
+        return helper.h(
+          "nav#dc-header-links.dc-custom-headers-links.d-none.d-md-block",
+          [
+            links,
+            h("dc-dropdown#dc-take-action-link", {
+              label: "Take Action!",
+              items: JSON.stringify([
+                {
+                  text: "Events",
+                  href: "https://community.debtcollective.org/calendar",
+                  target: "_blank"
+                },
+                {
+                  text: "Student Debt Strike",
+                  href: "https://strike.debtcollective.org/",
+                  target: "_blank"
+                },
+                {
+                  text: "Dispute Your Debt",
+                  href: "https://tools.debtcollective.org/",
+                  target: "_blank"
+                }
+              ])
+            })
+          ]
+        );
       });
     });
   }

--- a/scss/widgets/header.scss
+++ b/scss/widgets/header.scss
@@ -115,6 +115,10 @@
   @extend %navigation-link;
   font-weight: $font-weight-bold;
   margin-right: 1rem;
+
+  &:last-of-type {
+    margin-right: 0;
+  }
 }
 
 .d-header.with-user .d-header-icons {
@@ -125,4 +129,9 @@
     position: absolute;
     left: 0;
   }
+}
+
+// Hide the custom header links when the user scrolls in a topic
+.extra-info-wrapper + .panel .dc-custom-headers-links {
+  visibility: hidden;
 }


### PR DESCRIPTION
**What:**
- Integrate the dc-dropdown component to display the `Take action` links
- Fix the header, hide menu items when the user is in a topic

**Why:**
Closes: https://www.loom.com/share/18ef071052574360b77c83b7495d2413

**How:**
- Load the script for the `@debtcollective/dc-header-component` package to use the `dc-dropdown`
- Avoid displaying the menu items when the user scrolls down inside a topic

#### Media
https://www.loom.com/share/18ef071052574360b77c83b7495d2413

