### PR TITLE
Make header logo route to the home page

### DIFF
--- a/javascripts/discourse/initializers/dc-home-logo.js.es6
+++ b/javascripts/discourse/initializers/dc-home-logo.js.es6
@@ -48,7 +48,7 @@ export default {
             "a",
             {
               attributes: {
-                href: this.href(),
+                href: "https://debtcollective.org/",
                 "data-auto-route": true,
                 class: "built-in-logo"
               }

--- a/javascripts/discourse/templates/components/dc-menu.hbs
+++ b/javascripts/discourse/templates/components/dc-menu.hbs
@@ -1,7 +1,7 @@
 <div class="dc-header-cloak" {{on "click" this.closeMenu}}></div>
 <div class="dc-menu-content">
   <header class="dc-menu-content-header">
-    <a class="btn-transparent" href={{homepageURL}} {{on "click" this.closeMenu}}>
+    <a class="btn-transparent" href="https://debtcollective.org/">
       <img class="dc-menu-logo" src="{{siteSettings.site_logo_url}}" alt="{{siteSettings.title}}" />
     </a>
     <button class="btn-transparent btn-close material-icons" aria-label="close menu" {{on "click" this.closeMenu}}>


### PR DESCRIPTION
**What:**
Make header logo route to the home page

**Why:**
Closes: https://app.asana.com/0/1168997577035609/1198498074643140/f

**How:**
Change the src attr for the logo links to redirect the user to the home page

#### Media:
https://www.loom.com/share/a3ae8c1cd72b4fa18078e193d3c1996d
