### PR TITLE
Category media support

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -26,6 +26,7 @@
 @import "templates/components/list-controls";
 @import "templates/components/navigation-bar";
 @import "templates/components/topic-list";
+@import "templates/navigation/category";
 @import "templates/composer";
 @import "templates/topic";
 @import "templates/user";

--- a/javascripts/discourse/templates/navigation/category.hbs
+++ b/javascripts/discourse/templates/navigation/category.hbs
@@ -1,0 +1,42 @@
+{{#d-section class="navigation-container"}}
+  {{add-category-tag-classes category=category}}
+  {{#if category.uploaded_background.url}}
+    <section
+      class="category-heading with-background"
+      style="background-image: url({{category.uploaded_background.url}});"
+    >
+      {{#if category.uploaded_logo.url}}
+        {{cdn-img
+          src=category.uploaded_logo.url
+          class="category-logo"
+          width=category.uploaded_logo.width
+          height=category.uploaded_logo.height
+        }}
+      {{/if}}
+    </section>
+  {{else}}
+    <section class="category-heading">
+      {{#if category.uploaded_logo.url}}
+        {{cdn-img
+          src=category.uploaded_logo.url
+          class="category-logo"
+          width=category.uploaded_logo.width
+          height=category.uploaded_logo.height
+        }}
+      {{/if}}
+    </section>
+  {{/if}}
+  <div class="category-navigation">
+    {{d-navigation
+      category=category
+      filterMode=filterMode
+      noSubcategories=noSubcategories
+      canCreateTopic=canCreateTopic
+      createTopic=(route-action "createTopic")
+      createTopicDisabled=cannotCreateTopicOnCategory
+      hasDraft=draft
+      editCategory=(route-action "editCategory" category)
+    }}
+    {{plugin-outlet name="category-navigation" args=(hash category=category)}}
+  </div>
+{{/d-section}}

--- a/scss/templates/components/list-controls.scss
+++ b/scss/templates/components/list-controls.scss
@@ -23,6 +23,11 @@ body {
     align-items: center;
   }
 
+  .navigation-container {
+    display: flex;
+    flex-direction: column;
+  }
+
   #create-topic,
   .btn {
     order: 1;

--- a/scss/templates/navigation/category.scss
+++ b/scss/templates/navigation/category.scss
@@ -6,12 +6,31 @@
     background-position: center;
     background-size: cover;
     display: flex;
-    height: 20rem;
-    margin-bottom: 5rem;
+    height: 11rem;
+    margin-bottom: 3rem;
 
     .category-logo {
       margin-top: auto;
-      margin-bottom: -4rem;
+      margin-bottom: -2rem;
+    }
+
+    .aspect-image {
+      --max-height: 4.5rem;
+    }
+  }
+
+  @include media-breakpoint-up(lg) {
+    &.with-background {
+      height: 22.5rem;
+      margin-bottom: 5rem;
+
+      .category-logo {
+        margin-bottom: -4rem;
+      }
+
+      .aspect-image {
+        --max-height: 9rem;
+      }
     }
   }
 }

--- a/scss/templates/navigation/category.scss
+++ b/scss/templates/navigation/category.scss
@@ -1,6 +1,19 @@
 .category-heading {
   margin-bottom: 2rem;
   width: 100%;
+
+  &.with-background {
+    background-position: center;
+    background-size: cover;
+    display: flex;
+    height: 20rem;
+    margin-bottom: 5rem;
+
+    .category-logo {
+      margin-top: auto;
+      margin-bottom: -4rem;
+    }
+  }
 }
 
 // Avoid to tweak template to hide description

--- a/scss/templates/navigation/category.scss
+++ b/scss/templates/navigation/category.scss
@@ -1,0 +1,14 @@
+.category-heading {
+  margin-bottom: 2rem;
+  width: 100%;
+}
+
+// Avoid to tweak template to hide description
+.category-heading p {
+  display: none;
+}
+
+// Avoid default behaviour background to shown as body background
+body {
+  background-image: none !important;
+}


### PR DESCRIPTION
**What:**
Allow admins to add icon and backgrounds to a category without breaking the layout

**Why:**
Effort related to [Add category icon support](https://app.asana.com/0/1168997577035609/1198728038880465)

**How:**
- Replace the categories template to allow background customisation class
_(category template is not tight to any component so we are not able to do anything but replace or CSS styles)_

**Media:**
https://www.loom.com/share/5734d5688017485fb3fe4d06bbec5421

![image](https://user-images.githubusercontent.com/1425162/99838807-fa8c6f00-2b69-11eb-8406-19d843f99897.png)
