### PR TITLE
Aesthetics update over sub header nav

### DIFF
--- a/javascripts/discourse/initializers/dc-header.js.es6
+++ b/javascripts/discourse/initializers/dc-header.js.es6
@@ -23,7 +23,7 @@ export default {
         didInsertElement() {
           this._super();
           loadStencilScript(
-            "https://unpkg.com/@debtcollective/dc-dropdown-component@1.6.3/dist/dropdown-component/dropdown-component.esm.js"
+            "https://unpkg.com/@debtcollective/dc-dropdown-component@latest/dist/dropdown-component/dropdown-component.esm.js"
           );
         },
         afterRender() {

--- a/scss/connectors/categories-nav.scss
+++ b/scss/connectors/categories-nav.scss
@@ -1,6 +1,6 @@
 $dc-header-box-shadow: "0 0.125rem 0.25rem -0.0625rem rgba(0, 0, 0, 0.25)";
 $dc-categories-border: "0.0625rem solid #ebe7dc";
-$dc-categories-height-base: 4rem;
+$dc-categories-height-base: 3rem;
 $dc-categories-height-base-sm: $dc-categories-height-base * 0.875;
 
 #main-outlet {
@@ -81,7 +81,6 @@ $dc-categories-height-base-sm: $dc-categories-height-base * 0.875;
     }
 
     @include media-breakpoint-up(lg) {
-      font-size: $font-size-base;
       height: $dc-categories-height-base;
     }
   }


### PR DESCRIPTION
**What:**
Reduce the size of the sub header navigation to keep visual hierarchy

**Why:**
The sub header nav should remain as links that we want to highlight but not as items we want to take precedence over 
everything in regards navigation. This suppose to be shortcuts for people that are somehow used to the community or
new comers that are exploring the page.

**How:**
Reduce size ~20%

**Extras:**
- Add `@latest` to pull always latest version of dc-dropdown-component

**Media:**
![http://recordit.co/ItJWQRc9Ds](http://recordit.co/ItJWQRc9Ds.gif)