### PR TITLE
fix(background): add !important to background gradient

### DIFF
--- a/scss/layout.scss
+++ b/scss/layout.scss
@@ -1,5 +1,6 @@
 body {
-  background: $background-gradient;
+  // !important to disable the 'Category Background Image' feature
+  background: $background-gradient !important;
 
   // Up to some extend #main is the actual "body" of the page
   &,

--- a/scss/templates/navigation/category.scss
+++ b/scss/templates/navigation/category.scss
@@ -39,8 +39,3 @@
 .category-heading p {
   display: none;
 }
-
-// Avoid default behaviour background to shown as body background
-body {
-  background-image: none !important;
-}


### PR DESCRIPTION
**What:**

before:
![image](https://user-images.githubusercontent.com/849872/100143564-20ac5a80-2e5b-11eb-8621-9eb72c8ede96.png)

after:
![image](https://user-images.githubusercontent.com/849872/100143588-29049580-2e5b-11eb-9cac-4fb460964ac5.png)

**Why:** Fix bug introduced in https://github.com/debtcollective/discourse-debtcollective-theme/commit/548a2bc8009ec703257b264139f4933d3647d057#diff-0c7610e42df35f47e6b223cb81e30220178b8d03cc6cd1dba2dfe9eb2d98a0efR44-R46

**How:**

- make background gradient `!important`