### PR TITLE
Remove our collectives and rename other categories

### DIFF
--- a/javascripts/discourse/components/categories-only.js.es6
+++ b/javascripts/discourse/components/categories-only.js.es6
@@ -9,7 +9,7 @@ export default Component.extend({
   currentEfforts: [],
 
   @discourseComputed("categories")
-  nonCollectives(categories) {
+  topicCategories(categories) {
     return categories.filter(category => !category.tdc_is_collective);
   },
 

--- a/javascripts/discourse/components/categories-only.js.es6
+++ b/javascripts/discourse/components/categories-only.js.es6
@@ -9,11 +9,6 @@ export default Component.extend({
   currentEfforts: [],
 
   @discourseComputed("categories")
-  collectives(categories) {
-    return categories.filter(category => category.tdc_is_collective);
-  },
-
-  @discourseComputed("categories")
   nonCollectives(categories) {
     return categories.filter(category => !category.tdc_is_collective);
   },

--- a/javascripts/discourse/templates/components/categories-only.hbs
+++ b/javascripts/discourse/templates/components/categories-only.hbs
@@ -1,5 +1,5 @@
 {{! https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/components/categories-only.hbs }}
 {{dc-categories-only
-  nonCollectives=nonCollectives
+  topicCategories=topicCategories
   currentEfforts=currentEfforts
 }}

--- a/javascripts/discourse/templates/components/categories-only.hbs
+++ b/javascripts/discourse/templates/components/categories-only.hbs
@@ -1,6 +1,5 @@
 {{! https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/components/categories-only.hbs }}
 {{dc-categories-only
   nonCollectives=nonCollectives
-  collectives=collectives
   currentEfforts=currentEfforts
 }}

--- a/javascripts/discourse/templates/components/dc-categories-only.hbs
+++ b/javascripts/discourse/templates/components/dc-categories-only.hbs
@@ -17,13 +17,13 @@
     </div>
   {{/if}}
 {{/if}}
-{{#if nonCollectives}}
+{{#if topicCategories}}
   <div class="dc-categories-container">
     <h2 class="dc-heading mt-4 mb-2">
-      {{theme-i18n "dc.categories.others.title"}}
+      {{theme-i18n "dc.categories.categories.title"}}
     </h2>
     <div class="dc-row mt-4">
-      {{#each nonCollectives as |c|}}
+      {{#each topicCategories as |c|}}
         <div class="dc-col-sm-6">
           {{dc-category-card category=c}}
         </div>

--- a/javascripts/discourse/templates/components/dc-categories-only.hbs
+++ b/javascripts/discourse/templates/components/dc-categories-only.hbs
@@ -17,33 +17,6 @@
     </div>
   {{/if}}
 {{/if}}
-{{#if collectives}}
-  <div class="dc-categories-container">
-    <div class="d-flex justify-content-between align-items-center mt-4 mb-2">
-      <h2 class="dc-heading m-0">
-        {{theme-i18n "dc.categories.collectives.title"}}
-      </h2>
-      <div class="category-actions">
-        {{#if showCategoryAdmin}}
-          {{categories-admin-dropdown
-            onChange=(action "selectCategoryAdminDropdownAction")
-            options=(hash triggerOnChangeOnTab=false)
-          }}
-        {{/if}}
-      </div>
-    </div>
-    <p>
-      {{{theme-i18n "dc.categories.collectives.description"}}}
-    </p>
-    <div class="dc-row mt-4">
-      {{#each collectives as |c|}}
-        <div class="dc-col-sm-6">
-          {{dc-category-card category=c}}
-        </div>
-      {{/each}}
-    </div>
-  </div>
-{{/if}}
 {{#if nonCollectives}}
   <div class="dc-categories-container">
     <h2 class="dc-heading mt-4 mb-2">

--- a/javascripts/discourse/templates/components/dc-category-card.hbs
+++ b/javascripts/discourse/templates/components/dc-category-card.hbs
@@ -5,6 +5,9 @@
 >
   <div class="dc-card__content">
     <h2 class="dc-card__title dc-clamp-2">
+      {{#if category.read_restricted}}
+        {{d-icon "lock"}}
+      {{/if}}
       {{category.name}}
     </h2>
     <div class="dc-card__text dc-clamp-2">

--- a/javascripts/discourse/templates/mobile/components/categories-only.hbs
+++ b/javascripts/discourse/templates/mobile/components/categories-only.hbs
@@ -1,2 +1,2 @@
 {{! https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/mobile/components/categories-only.hbs }}
-{{dc-categories-only nonCollectives=nonCollectives}}
+{{dc-categories-only topicCategories=topicCategories}}

--- a/javascripts/discourse/templates/mobile/components/categories-only.hbs
+++ b/javascripts/discourse/templates/mobile/components/categories-only.hbs
@@ -1,2 +1,2 @@
 {{! https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/mobile/components/categories-only.hbs }}
-{{dc-categories-only nonCollectives=nonCollectives collectives=collectives}}
+{{dc-categories-only nonCollectives=nonCollectives}}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -23,8 +23,8 @@ en:
         title: "Current efforts"
         description: "We strive to make accessible to you all the efforts that are happening right now around the debt collective organization.
         Below you can find some of those. Keep exploring the community to find out more"
-      others:
-        title: "Others categories"
+      categories:
+        title: "Categories"
     popup:
       title: "We've got a new look! What do you think?"
       description: Noticed the new layout for the Debt Collective Community platform? Implementing this took a lot of time and effort and we want to make sure the new system works for you. So, please let us know what is working well and what you may want to see done better!

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -23,10 +23,6 @@ en:
         title: "Current efforts"
         description: "We strive to make accessible to you all the efforts that are happening right now around the debt collective organization.
         Below you can find some of those. Keep exploring the community to find out more"
-      collectives:
-        title: "Our Collectives"
-        description: "When you join the Debt Collective you will be placed into a group based on your debt type. We call these groups <strong>collectives</strong>.
-        You will be able to meet other people in your situation to share information and learn how to fight back together against creditors and collectors."
       others:
         title: "Others categories"
     popup:


### PR DESCRIPTION
**What:**
- Remove `our collectives` section
- Rename `other categories` to `categories`
- Display a lock icon if a category is private

**Why:**
Closes: https://app.asana.com/0/1159164196409129/1199201056178941/f

**How:**
- Removing the code related to our collectives
- Renaming all the coincidences of `other categories` to be `categories`
- Modify the dc-category-card to display a lock icon if the category is `read_restricted`

#### Media
https://www.loom.com/share/9b2a295db2754c72b648649f390dbe83