### PR TITLE
redirect user to after_signup_path when they log in via email

### DIFF
--- a/javascripts/discourse/initializers/dc-email-login.js
+++ b/javascripts/discourse/initializers/dc-email-login.js
@@ -1,0 +1,42 @@
+import { ajax } from "discourse/lib/ajax";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+import { withPluginApi } from "discourse/lib/plugin-api";
+
+export default {
+  name: "dc-email-login",
+  initialize() {
+    withPluginApi("0.8.24", (api) => {
+      api.modifyClass("controller:emailLogin", {
+        actions: {
+          finishLogin() {
+            let data = {
+              second_factor_method: this.secondFactorMethod,
+              timezone: moment.tz.guess(),
+            };
+            if (this.securityKeyCredential) {
+              data.second_factor_token = this.securityKeyCredential;
+            } else {
+              data.second_factor_token = this.secondFactorToken;
+            }
+
+            ajax({
+              url: `/session/email-login/${this.model.token}`,
+              type: "POST",
+              data: data,
+            })
+              .then((result) => {
+                if (result.success) {
+                  const redirectTo = result.redirect_to || "/";
+
+                  DiscourseURL.redirectTo(redirectTo);
+                } else {
+                  this.set("model.error", result.error);
+                }
+              })
+              .catch(popupAjaxError);
+          },
+        },
+      });
+    });
+  },
+};


### PR DESCRIPTION
**What:** redirect the user to after_signup_path when they log in via email

**Why:** Related to https://app.asana.com/0/1168997577035609/1199911153376989

**How:**

The backend now returns a value called `redirect_to` in the email login response. If this value is present we need to do the redirection. This functionality was added here https://github.com/debtcollective/discourse-debtcollective-sso/pull/16