### PR TITLE
Adjust topic list item

### DIFF
--- a/javascripts/discourse/components/dc-topic-card-content.js.es6
+++ b/javascripts/discourse/components/dc-topic-card-content.js.es6
@@ -1,10 +1,21 @@
 import discourseComputed from "discourse-common/utils/decorators";
+import { computed } from "@ember/object";
 import Component from "@ember/component";
 
 export default Component.extend({
   tagName: "div",
   classNames: ["dc-topic-card-content", "h-100"],
   classNameBindings: ["isUnread:is-unread:already-seen"],
+
+  topicAuthor: computed(function() {
+    return this.topic.posters[0].user;
+  }),
+  lastRepliedAuthor: computed(function() {
+    return this.topic.lastPoster.user;
+  }),
+  isUnreplied: computed(function() {
+    return this.topic.replyCount === 0;
+  }),
 
   didInsertElement() {
     this._bindClasses();

--- a/javascripts/discourse/helpers/dc-format-date.js.es6
+++ b/javascripts/discourse/helpers/dc-format-date.js.es6
@@ -5,8 +5,12 @@ import { shortDate } from "discourse/lib/formatter";
  * Avoid the need of open components and modify models
  * in order to format the date with Discourse shortDate
  * function. Examples of usage of this function can be found
- * at https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/controllers/composer.js.es6#L420
+ * at https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/app/controllers/composer.js#L454
  */
 registerUnbound("dc-format-date", function(val) {
   return new Handlebars.SafeString(shortDate(val));
+});
+
+registerUnbound("dc-relative-date", function(val) {
+  return new Handlebars.SafeString(moment(val).fromNow());
 });

--- a/javascripts/discourse/templates/components/dc-category-card.hbs
+++ b/javascripts/discourse/templates/components/dc-category-card.hbs
@@ -4,32 +4,32 @@
   style="border-top-color: #{{category.color}};"
 >
   <div class="dc-card__content">
-    <h2 class="dc-card__title dc-clamp-2">
+    <h2 class="dc-card__title dc-clamp-2 has-icon">
       {{#if category.read_restricted}}
         {{d-icon "lock"}}
       {{/if}}
       {{category.name}}
+      <div class="dc-card__meta">
+        <span class="material-icons">
+          forum
+        </span>
+        <p class="m-0 ml-1 dc-text-light">
+          {{category.totalTopicCount}}
+        </p>
+        {{#if category.tdc_is_collective}}
+          <span class="ml-2 material-icons">
+            supervisor_account
+          </span>
+          <p class="m-0 ml-1 dc-text-light">
+            {{groupCount}}
+          </p>
+        {{/if}}
+      </div>
     </h2>
     <div class="dc-card__text dc-clamp-2">
       {{#if category.description_excerpt}}
         {{{dir-span category.description_excerpt}}}
       {{/if}}
     </div>
-  </div>
-  <div class="dc-card__meta">
-    <span class="material-icons">
-      forum
-    </span>
-    <p class="m-0 ml-1 dc-text-light">
-      {{category.totalTopicCount}}
-    </p>
-    {{#if category.tdc_is_collective}}
-      <span class="ml-2 material-icons">
-        supervisor_account
-      </span>
-      <p class="m-0 ml-1 dc-text-light">
-        {{groupCount}}
-      </p>
-    {{/if}}
   </div>
 </a>

--- a/javascripts/discourse/templates/components/dc-topic-card-content.hbs
+++ b/javascripts/discourse/templates/components/dc-topic-card-content.hbs
@@ -27,20 +27,30 @@
             </div>
           </h2>
           <div class="dc-card__meta dc-text-small">
-            {{#if topic.pinned}}
-              <p
-                class="dc-info-pill mr-1"
-                style="background-color: #{{topic.category.color}};"
-              >
-                staff post
-              </p>
-            {{/if}}
+            <p class="mr-1">
+              <strong>
+                {{#if isUnreplied}}
+                  {{topicAuthor.displayName}}
+                {{else}}
+                  <small class="material-icons reply-icon">
+                    reply
+                  </small>
+                  {{lastRepliedAuthor.displayName}}
+                {{/if}}
+              </strong>
+            </p>
             <p class="dc-text-light">
-              {{#if topic.pinned}}
-                ·
+              {{#if isUnreplied}}
+                started
+                <span>
+                  {{dc-relative-date topic.createdAt}}
+                </span>
+              {{else}}
+                replied
+                <span>
+                  {{dc-relative-date topic.last_posted_at}}
+                </span>
               {{/if}}
-              started
-              {{dc-relative-date topic.createdAt}}
             </p>
           </div>
         </header>

--- a/javascripts/discourse/templates/components/dc-topic-card-content.hbs
+++ b/javascripts/discourse/templates/components/dc-topic-card-content.hbs
@@ -43,10 +43,12 @@
             </p>
           </div>
         </header>
-        {{#if topic.hasExcerpt}}
-          <div class="dc-card__text dc-clamp-1">
-            {{{dir-span topic.escapedExcerpt}}}
-          </div>
+        {{#if topic.pinned}}
+          {{#if topic.hasExcerpt}}
+            <div class="dc-card__text dc-clamp-2">
+              {{{dir-span topic.escapedExcerpt}}}
+            </div>
+          {{/if}}
         {{/if}}
       </div>
     </div>

--- a/javascripts/discourse/templates/components/dc-topic-card-content.hbs
+++ b/javascripts/discourse/templates/components/dc-topic-card-content.hbs
@@ -12,27 +12,35 @@
   <div class="dc-col">
     <div class="d-flex flex-column justify-content-between h-100">
       <div class="dc-card__content">
-        <header class="dc-card__header">
-          <div>
-            <h2 class="dc-card__title dc-clamp-2">
-              {{{topic.fancyTitle}}}
-            </h2>
-            <div class="dc-card__meta dc-text-small">
-              {{#if topic.pinned}}
-                <p
-                  class="dc-info-pill mr-1"
-                  style="background-color: #{{topic.category.color}};"
-                >
-                  staff post
-                </p>
-              {{/if}}
-              <p class="dc-text-light">
-                {{#if topic.pinned}}
-                  ·
-                {{/if}}
-                {{dc-format-date topic.createdAt}}
+        <header
+          class="dc-card__header dc-card__header d-flex justify-content-center flex-column align-items-stretch"
+        >
+          <h2 class="dc-card__title dc-clamp-2 has-icon">
+            {{{topic.fancyTitle}}}
+            <div class="dc-card__meta">
+              <span class="material-icons">
+                comment
+              </span>
+              <p class="m-0 ml-1 dc-text-light">
+                {{topic.replyCount}}
               </p>
             </div>
+          </h2>
+          <div class="dc-card__meta dc-text-small">
+            {{#if topic.pinned}}
+              <p
+                class="dc-info-pill mr-1"
+                style="background-color: #{{topic.category.color}};"
+              >
+                staff post
+              </p>
+            {{/if}}
+            <p class="dc-text-light">
+              {{#if topic.pinned}}
+                ·
+              {{/if}}
+              {{dc-format-date topic.createdAt}}
+            </p>
           </div>
         </header>
         {{#if topic.hasExcerpt}}
@@ -40,18 +48,6 @@
             {{{dir-span topic.escapedExcerpt}}}
           </div>
         {{/if}}
-      </div>
-      <div class="dc-row">
-        <div class="dc-col">
-          <div class="dc-card__meta">
-            <span class="material-icons">
-              comment
-            </span>
-            <p class="m-0 ml-1 dc-text-light">
-              {{topic.replyCount}}
-            </p>
-          </div>
-        </div>
       </div>
     </div>
   </div>

--- a/javascripts/discourse/templates/components/dc-topic-card-content.hbs
+++ b/javascripts/discourse/templates/components/dc-topic-card-content.hbs
@@ -39,7 +39,8 @@
               {{#if topic.pinned}}
                 ·
               {{/if}}
-              {{dc-format-date topic.createdAt}}
+              started
+              {{dc-relative-date topic.createdAt}}
             </p>
           </div>
         </header>

--- a/javascripts/discourse/templates/components/dc-topic-card-content.hbs
+++ b/javascripts/discourse/templates/components/dc-topic-card-content.hbs
@@ -17,17 +17,12 @@
         >
           <h2 class="dc-card__title dc-clamp-2 has-icon">
             {{{topic.fancyTitle}}}
-            <div class="dc-card__meta">
-              <span class="material-icons">
-                comment
-              </span>
-              <p class="m-0 ml-1 dc-text-light">
-                {{topic.replyCount}}
-              </p>
+            <div class="hidden d-sm-block">
+              {{dc-topic-engagement topic=topic}}
             </div>
           </h2>
           <div class="dc-card__meta dc-text-small">
-            <p class="mr-1">
+            <p class="dc-clamp-1">
               <strong>
                 {{#if isUnreplied}}
                   {{topicAuthor.displayName}}
@@ -38,19 +33,19 @@
                   {{lastRepliedAuthor.displayName}}
                 {{/if}}
               </strong>
-            </p>
-            <p class="dc-text-light">
-              {{#if isUnreplied}}
-                started
-                <span>
-                  {{dc-relative-date topic.createdAt}}
-                </span>
-              {{else}}
-                replied
-                <span>
-                  {{dc-relative-date topic.last_posted_at}}
-                </span>
-              {{/if}}
+              <span class="dc-text-light">
+                {{#if isUnreplied}}
+                  started
+                  <span>
+                    {{dc-relative-date topic.createdAt}}
+                  </span>
+                {{else}}
+                  replied
+                  <span>
+                    {{dc-relative-date topic.last_posted_at}}
+                  </span>
+                {{/if}}
+              </span>
             </p>
           </div>
         </header>

--- a/javascripts/discourse/templates/components/dc-topic-card-content.hbs
+++ b/javascripts/discourse/templates/components/dc-topic-card-content.hbs
@@ -16,6 +16,9 @@
           class="dc-card__header dc-card__header d-flex justify-content-center flex-column align-items-stretch"
         >
           <h2 class="dc-card__title dc-clamp-2 has-icon">
+            {{#if topic.pinned}}
+              {{d-icon "thumbtack"}}
+            {{/if}}
             {{{topic.fancyTitle}}}
             <div class="hidden d-sm-block">
               {{dc-topic-engagement topic=topic}}

--- a/javascripts/discourse/templates/components/dc-topic-engagement.hbs
+++ b/javascripts/discourse/templates/components/dc-topic-engagement.hbs
@@ -1,0 +1,16 @@
+<div class="dc-card__meta">
+  <span class="material-icons">
+    comment
+  </span>
+  <p class="m-0 ml-1 dc-text-light">
+    {{topic.replyCount}}
+  </p>
+  {{#if topic.liked}}
+    <span class="material-icons m-0 ml-2">
+      favorite
+    </span>
+    <p class="m-0 ml-1 dc-text-light">
+      {{topic.like_count}}
+    </p>
+  {{/if}}
+</div>

--- a/javascripts/discourse/templates/components/topic-list.hbs
+++ b/javascripts/discourse/templates/components/topic-list.hbs
@@ -7,7 +7,7 @@
           {{dc-topic-list-item-small topic=topic}}
         </div>
       {{else}}
-        <div class="dc-col-sm-6 dc-col-lg-12">
+        <div class="dc-col-12">
           {{topic-list-item
             topic=topic
             bulkSelectEnabled=bulkSelectEnabled

--- a/scss/button.scss
+++ b/scss/button.scss
@@ -61,3 +61,7 @@
 .btn.login-with-email-button {
   height: 40px;
 }
+
+.btn.edit-category .d-button-label {
+  margin-left: 0.5rem;
+}

--- a/scss/card.scss
+++ b/scss/card.scss
@@ -3,7 +3,6 @@
   box-shadow: $card-box-shadow;
   border-top: 0.25rem solid transparent;
   display: flex;
-  height: $card-height;
   justify-content: space-between;
   flex-direction: column;
   margin-bottom: 1.5rem;
@@ -47,6 +46,17 @@
     justify-content: space-between;
   }
 
+  &__title.has-icon {
+    position: relative;
+    padding-right: 4rem;
+
+    .dc-card__meta {
+      position: absolute;
+      top: 0;
+      right: 0;
+    }
+  }
+
   &__meta {
     display: flex;
     align-items: center;
@@ -57,6 +67,11 @@
       margin: 0;
     }
   }
+}
+
+.dc-category.dc-card {
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
 }
 
 .icons-line {

--- a/scss/card.scss
+++ b/scss/card.scss
@@ -66,6 +66,13 @@
     p {
       margin: 0;
     }
+
+    .reply-icon {
+      font-size: $font-size-sm;
+      margin: 0;
+      position: relative;
+      top: $spacer * 0.125;
+    }
   }
 }
 

--- a/scss/card.scss
+++ b/scss/card.scss
@@ -48,7 +48,11 @@
 
   &__title.has-icon {
     position: relative;
-    padding-right: 4rem;
+
+    @include media-breakpoint-up(sm) {
+      // Enough space to likes and comments up to 9k both
+      padding-right: 10rem;
+    }
 
     .dc-card__meta {
       position: absolute;

--- a/scss/templates/components/d-navigation.scss
+++ b/scss/templates/components/d-navigation.scss
@@ -87,8 +87,9 @@ ol.category-breadcrumb {
     align-items: center;
     display: flex;
 
-    .badge-category {
-      color: $gray;
+    .badge-category,
+    .d-icon {
+      color: $black;
     }
 
     .badge-category-bg {

--- a/scss/templates/components/list-controls.scss
+++ b/scss/templates/components/list-controls.scss
@@ -11,7 +11,7 @@ body {
 }
 
 .list-controls {
-  margin-bottom: 3rem;
+  margin-bottom: 1.5rem;
 
   .select-kit.categories-admin-dropdown,
   .select-kit.tags-admin-dropdown,

--- a/scss/templates/components/topic-list.scss
+++ b/scss/templates/components/topic-list.scss
@@ -4,3 +4,10 @@
   border-radius: 0;
   box-shadow: none;
 }
+
+.topic-list-icons .d-icon-thumbtack,
+.topic-list .d-icon-thumbtack,
+.latest-topic-list .d-icon-thumbtack,
+.top-topic-list .d-icon-thumbtack {
+  color: $black;
+}

--- a/scss/templates/list/dc-topic-card.scss
+++ b/scss/templates/list/dc-topic-card.scss
@@ -21,6 +21,7 @@
 
   .dc-card__title {
     font-size: $font-size-base;
+    margin-top: $spacer * 0.75 !important;
   }
 
   footer {

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -28,7 +28,7 @@ $font-family-sans-serif: "Libre Franklin", sans-serif;
 $font-family-monospace: "More Gothic Bold", Impact, sans-serif;
 
 $font-size-base: 1rem;
-$font-size-lg: 1rem * 1.25;
+$font-size-lg: 1rem * 1.125;
 $font-size-xl: 1rem * 1.5;
 $font-size-sm: 1rem * 0.875;
 $font-size-xs: 1rem * 0.75;

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -61,8 +61,6 @@ $danger: #dc3545;
 $light: #f8f9fa;
 $dark: #3c3c3c;
 
-// As flex layout the height will affect vertical space
-$card-height: 13rem;
 $btn-action-color: $secondary;
 
 $header-height: 5rem;


### PR DESCRIPTION
**What:**
Update topic/category list screens to meet design expectations

**Why:**
relates to https://app.asana.com/0/1168997577035609/1199650841826375

**How:**
- Adjust cards in regards category and topic items
- Update large font to be ~18px
- Add better metadata to topic list items (created and replied dates)
- Update breadcrump icon colors
- Pinned icon for topic pinned

**Media:**
https://www.loom.com/share/fef9c3aea61a4be69cc1ecb459ce1f1d

![Mobile category list screenshot](https://user-images.githubusercontent.com/1425162/108590455-fa1b9400-7363-11eb-8363-55348ceb2984.png)
![Mobile topic list screenshot](https://user-images.githubusercontent.com/1425162/108521802-664ab900-72cc-11eb-8a9d-90b136faf24e.png)
