### PR TITLE
fix: add missing DiscourseURL import

### DIFF
--- a/javascripts/discourse/initializers/dc-email-login.js
+++ b/javascripts/discourse/initializers/dc-email-login.js
@@ -1,6 +1,7 @@
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { withPluginApi } from "discourse/lib/plugin-api";
+import DiscourseURL from "discourse/lib/url";
 
 export default {
   name: "dc-email-login",

--- a/javascripts/discourse/initializers/dc-post.js.es6
+++ b/javascripts/discourse/initializers/dc-post.js.es6
@@ -2,6 +2,7 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 import { transformBasicPost } from "discourse/lib/transform-post";
 import { postTransformCallbacks } from "discourse/widgets/post-stream";
 import { h } from "virtual-dom";
+import DiscourseURL from "discourse/lib/url";
 
 function transformWithCallbacks(post) {
   let transformed = transformBasicPost(post);


### PR DESCRIPTION
**What:** fix: add missing DiscourseURL import

**Why:** Closes https://sentry.io/organizations/debtcollective/issues/2231709891

**How:**

- Add missing import

**Notes:**

Seems like Sentry now supports Discourse's source maps