### PR TITLE
Sidebar and subcategories issue

### DIFF
--- a/javascripts/discourse/components/dc-sidebar-subcategories.js.es6
+++ b/javascripts/discourse/components/dc-sidebar-subcategories.js.es6
@@ -22,15 +22,15 @@ export default Component.extend({
       // Active category match this element category
       this.category.id === this.currentCategoryId ||
         // A subcategory of this parent has been clicked
-        this._expandBySubcategory() ||
-        // There is no current category
-        !!this.currentCategoryId
+        this._expandBySubcategory()
     );
   },
 
   _expandBySubcategory() {
     return this.category.isParent
-      ? this.category.subcategories.find(c => c.id === this.currentCategoryId)
+      ? Boolean(
+          this.category.subcategories.find(c => c.id === this.currentCategoryId)
+        )
       : false;
   }
 });

--- a/javascripts/discourse/templates/components/dc-sidebar-link.hbs
+++ b/javascripts/discourse/templates/components/dc-sidebar-link.hbs
@@ -1,7 +1,7 @@
 {{! letting the component define the anchor tag will make things harder to use router }}
 <a
   id="sidebar-link-{{category.id}}"
-  class="dynamic-hover-color dc-clamp-1"
+  class="dynamic-hover-color sidebar-link-clamp"
   style="color: #{{category.color}};"
   href="{{category.url}}"
   {{action "handlOnClick" category.id}}

--- a/javascripts/discourse/templates/navigation/category.hbs
+++ b/javascripts/discourse/templates/navigation/category.hbs
@@ -26,6 +26,8 @@
   {{/if}}
   <div
     class="category-navigation
+      {{unless category.uploaded_background.url "mt-4"}}
+
       {{if themeSettings.show_sidebar "dc-sidebar-visible"}}"
   >
     {{d-navigation

--- a/scss/templates/components/dc-sidebar.scss
+++ b/scss/templates/components/dc-sidebar.scss
@@ -62,3 +62,8 @@
   // Allows to get hover color from inline style
   color: inherit !important;
 }
+
+.sidebar-link-clamp {
+  // Solve issue on Safari browser when rendering long categories as line-height is no standard
+  @include clamp-text(1, true, 2.25em);
+}


### PR DESCRIPTION
**What:**
Make sure subcategories are visible only once the parent gets clicked

**Why:**
Previously all parents expanded on click one item of the sidebar
https://app.asana.com/0/1168997577035609/1199957006065245

**How:**
Adjust condition to expand to remove unnecessary rule

**Extras:**
Minor aesthetics fixes for Safari sidebar items when excerpt is active, besides, add some small top margin for category titles when they don't have any background image.

**Media:**
https://www.loom.com/share/45cbda5b90d34643829abcb8340d7304