### PR TITLE
Sidebar links

### DIFF
--- a/javascripts/discourse/components/dc-sidebar.js.es6
+++ b/javascripts/discourse/components/dc-sidebar.js.es6
@@ -1,4 +1,5 @@
 import Component from "@ember/component";
+import discourseComputed from "discourse-common/utils/decorators";
 import { computed } from "@ember/object";
 
 export default Component.extend({
@@ -10,6 +11,16 @@ export default Component.extend({
   categories: computed(function() {
     return this.site.get("categoriesList");
   }),
+
+  @discourseComputed("currentURL")
+  isLatestPage(currentURL) {
+    return currentURL === "/latest" || currentURL === "/";
+  },
+
+  @discourseComputed("currentURL")
+  isEventsPage(currentURL) {
+    return currentURL === "/calendar";
+  },
 
   didInsertElement() {
     this._super(...arguments);

--- a/javascripts/discourse/components/dc-sidebar.js.es6
+++ b/javascripts/discourse/components/dc-sidebar.js.es6
@@ -19,7 +19,7 @@ export default Component.extend({
 
   @discourseComputed("currentURL")
   isEventsPage(currentURL) {
-    return currentURL === "/calendar";
+    return currentURL === settings.events_url;
   },
 
   didInsertElement() {

--- a/javascripts/discourse/initializers/dc-homepage.js.es6
+++ b/javascripts/discourse/initializers/dc-homepage.js.es6
@@ -1,9 +1,13 @@
+import { setDefaultHomepage } from "discourse/lib/utilities";
 import { withPluginApi } from "discourse/lib/plugin-api";
 
 export default {
   name: "dc-homepage",
   initialize() {
     withPluginApi("0.8", api => {
+      // Define arbitrary hompage url
+      setDefaultHomepage("/latest");
+
       api.modifyClass("route:discovery-categories", {
         findCategories() {
           return this._findCategoriesAndTopics("latest");

--- a/javascripts/discourse/templates/components/d-navigation.hbs
+++ b/javascripts/discourse/templates/components/d-navigation.hbs
@@ -6,7 +6,7 @@
 }}
 {{#if isLatestPage}}
   <p class="page-description mt-0 mt-lg-3">
-    In this section you will find everything that is happening right now within the community
+    In this section you will find everything that is happening right now within the community. If you want to see an specific subject filter by a category that best describe what you are looking for
   </p>
 {{/if}}
 {{#if category}}

--- a/javascripts/discourse/templates/components/d-navigation.hbs
+++ b/javascripts/discourse/templates/components/d-navigation.hbs
@@ -5,7 +5,7 @@
   noSubcategories=noSubcategories
 }}
 {{#if isLatestPage}}
-  <p class="page-description">
+  <p class="page-description mt-0 mt-lg-3">
     In this section you will find everything that is happening right now within the community
   </p>
 {{/if}}

--- a/javascripts/discourse/templates/components/dc-sidebar.hbs
+++ b/javascripts/discourse/templates/components/dc-sidebar.hbs
@@ -23,7 +23,7 @@
   </a>
   <a
     class="sidebar-raw-link {{if isEventsPage "active"}}"
-    href="/calendar"
+    href="{{themeSettings.events_url}}"
     {{action "handleClickLink" null}}
   >
     All events

--- a/javascripts/discourse/templates/components/dc-sidebar.hbs
+++ b/javascripts/discourse/templates/components/dc-sidebar.hbs
@@ -15,11 +15,18 @@
 </div>
 <div class="m-0 d-flex flex-column">
   <a
-    class="sidebar-raw-link {{unless activeCategoryId "active"}}"
+    class="sidebar-raw-link {{if isLatestPage "active"}}"
     href="/latest"
     {{action "handleClickLink" null}}
   >
     All discussions
+  </a>
+  <a
+    class="sidebar-raw-link {{if isEventsPage "active"}}"
+    href="/calendar"
+    {{action "handleClickLink" null}}
+  >
+    All events
   </a>
 </div>
 <ul class="list-unstyled scrollable-area">

--- a/javascripts/discourse/templates/components/dc-sidebar.hbs
+++ b/javascripts/discourse/templates/components/dc-sidebar.hbs
@@ -16,10 +16,10 @@
 <div class="m-0 d-flex flex-column">
   <a
     class="sidebar-raw-link {{unless activeCategoryId "active"}}"
-    href="/categories"
+    href="/latest"
     {{action "handleClickLink" null}}
   >
-    All categories
+    All discussions
   </a>
 </div>
 <ul class="list-unstyled scrollable-area">

--- a/javascripts/discourse/templates/discovery.hbs
+++ b/javascripts/discourse/templates/discovery.hbs
@@ -10,7 +10,7 @@
       {{#if themeSettings.show_sidebar}}
         <div class="dc-col-lg-3 dc-sidebar-hack-width">
           <div class="d-none d-lg-flex h-100">
-            {{dc-sidebar currentUser=currentUser}}
+            {{dc-sidebar currentUser=currentUser currentURL=router.currentURL}}
           </div>
         </div>
       {{/if}}

--- a/javascripts/discourse/templates/navigation/default.hbs
+++ b/javascripts/discourse/templates/navigation/default.hbs
@@ -5,7 +5,10 @@
 }}
   {{! We need to add a extra wrapper to being able to target this with CSS }}
   {{! Trying to customise with navigation-container won't take effect }}
-  <div class="dc-navigation-container">
+  <div
+    class="dc-navigation-container mt-lg-4
+      {{if themeSettings.show_sidebar "has-sidebar"}}"
+  >
     {{d-navigation
       filterMode=filterMode
       canCreateTopic=canCreateTopic

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -73,6 +73,11 @@
   }
 }
 
+ol.category-breadcrumb {
+  // to overcome discourse core code
+  display: block !important;
+}
+
 ol.category-breadcrumb .select-kit.combo-box .select-kit-header {
   font-size: 1.5rem;
 }

--- a/scss/templates/components/d-navigation.scss
+++ b/scss/templates/components/d-navigation.scss
@@ -27,6 +27,10 @@
     min-width: 100%;
   }
 
+  &.has-sidebar #create-topic {
+    display: none;
+  }
+
   // Avoid to show the link to catefories that will make the user go to the homepage
   a[href="/categories"] {
     display: none;

--- a/settings.yml
+++ b/settings.yml
@@ -27,6 +27,11 @@ show_sidebar:
   default: false
   description:
     en: "enable possibility to show sidebar navigation for large screens"
+events_url:
+  type: string
+  default: "/calendar"
+  desription:
+    en: "which page the users will visit to known about the upcoming events?"
 logo_href:
   type: string
   default: ""


### PR DESCRIPTION
**What:**
- Add "All discussions" and "All events" links to sidebar
- Remove "All categories" link

**Why:**
closes https://app.asana.com/0/1168997577035609/1199979488935304

**How:**
- Set default homepage to `/latest` as list of categories is now deprecated
- Add needed markup for links
- Allow through settings to have admin to set the "events url"
- Use `/calendar` as events url by default as `upcoming-events` is not found in production
- Update sidebar to have information about the route current url injecting router.currentURL

**Media:**
https://www.loom.com/share/480d9a01b93c4f8da11745583bc4ba23

![image](https://user-images.githubusercontent.com/1425162/111787960-de060680-88bf-11eb-8c59-b661558ed654.png)

_Worth to mention that mobile devices don't have a quick link to events, currently, the sidebar displays only for desktop and mobile devices relies on the category breadcrumb to navigate_