### PR TITLE
Position content below header and categories

### DIFF
--- a/scss/layout.scss
+++ b/scss/layout.scss
@@ -7,6 +7,10 @@ body {
   #main {
     min-height: 100%;
   }
+
+  #main {
+    padding-top: calc(#{$header-height + $dc-categories-height-base});
+  }
 }
 
 // Container we use is neither fluid or typical container from bootstrap. Instead, is a fluid with a max-width

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -64,3 +64,4 @@ $dark: #3c3c3c;
 $btn-action-color: $secondary;
 
 $header-height: 5rem;
+$dc-categories-height-base: 3rem;


### PR DESCRIPTION
**What:**
Position content below header and categories

**Why:**
closes: https://app.asana.com/0/1168997577035609/1200153835254134


**How:**
Add padding to the main content, this padding is the sum of the header and categories height


#### Bug
![image](https://user-images.githubusercontent.com/20747535/113614340-fabc7100-9617-11eb-90cb-bb2425816662.png)

#### Media
![image](https://user-images.githubusercontent.com/20747535/113613256-94831e80-9616-11eb-8449-a246bdbed000.png)
![image](https://user-images.githubusercontent.com/20747535/113613270-9816a580-9616-11eb-988c-81635187a180.png)
