### PR TITLE
remove "/" from setDefaultHomepage input

### DIFF
--- a/javascripts/discourse/initializers/dc-homepage.js.es6
+++ b/javascripts/discourse/initializers/dc-homepage.js.es6
@@ -6,7 +6,7 @@ export default {
   initialize() {
     withPluginApi("0.8", api => {
       // Define arbitrary hompage url
-      setDefaultHomepage("/latest");
+      setDefaultHomepage("latest");
 
       api.modifyClass("route:discovery-categories", {
         findCategories() {


### PR DESCRIPTION
**What:**
Prevent wrong usage over `setDefaultHomepage` method

**Why:**
https://sentry.io/organizations/debtcollective/issues/2372036190/?project=1393689

**How:**
following `app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js` it seems this method
doesn't expect the `/` and that might be related to the error at
https://sentry.io/organizations/debtcollective/issues/2372036190/?project=1393689

Check [reference code here](https://github.com/discourse/discourse/blob/dc6b547ed89f652b5406489d76140b76cf8e0d1d/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js#L159)

**Notes:**
I couldn't reproduce the issue but chances are that this doesn't prevent user from use the app and fallback to the setting default of the homepage.