### PR TITLE
Add dc-header-component instead discourse built-in

### DIFF
--- a/common/after_header.html
+++ b/common/after_header.html
@@ -1,0 +1,7 @@
+<dc-header
+  class="hydrated"
+  community="https://community.debtcollective.org"
+  homepage="https://debtcollective.org/"
+  host="https://community.debtcollective.org"
+  id="dc-header"
+></dc-header>

--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -1,0 +1,4 @@
+<script
+  type="module"
+  src="https://unpkg.com/@debtcollective/dc-header-component@latest/dist/header/header.esm.js"
+></script>

--- a/javascripts/discourse/initializers/dc-header.js.es6
+++ b/javascripts/discourse/initializers/dc-header.js.es6
@@ -56,18 +56,6 @@ export default {
         },
         didInsertElement() {
           this._super();
-          loadStencilScript(
-            "https://unpkg.com/@debtcollective/dc-header-component@latest/dist/header/header.esm.js"
-          );
-
-          // TODO: in order for CORS to work properly this values should come from ENV
-          addWebComponent("dc-header", {
-            class: "hydrated",
-            community: "https://community.debtcollective.org",
-            homepage: "https://debtcollective.org/",
-            host: "https://community.debtcollective.org",
-            id: "dc-header"
-          });
         },
         afterRender() {
           this._super();
@@ -239,25 +227,3 @@ export default {
     });
   }
 };
-
-function loadStencilScript(src) {
-  var scriptModule = document.createElement("script");
-  scriptModule.setAttribute("type", "module");
-  scriptModule.setAttribute("src", src);
-  document.head.appendChild(scriptModule);
-
-  var scriptNoModule = document.createElement("script");
-  scriptNoModule.setAttribute("nomodule", "");
-  scriptNoModule.setAttribute("src", src);
-  document.head.appendChild(scriptNoModule);
-}
-
-function addWebComponent(tag, attrs) {
-  var component = document.createElement(tag);
-
-  Object.keys(attrs).forEach(key => {
-    component.setAttribute(key, attrs[key]);
-  });
-
-  document.body.appendChild(component);
-}

--- a/javascripts/discourse/initializers/dc-header.js.es6
+++ b/javascripts/discourse/initializers/dc-header.js.es6
@@ -57,8 +57,17 @@ export default {
         didInsertElement() {
           this._super();
           loadStencilScript(
-            "https://unpkg.com/@debtcollective/dc-dropdown-component@latest/dist/dropdown-component/dropdown-component.esm.js"
+            "https://unpkg.com/@debtcollective/dc-header-component@latest/dist/header/header.esm.js"
           );
+
+          // TODO: in order for CORS to work properly this values should come from ENV
+          addWebComponent("dc-header", {
+            class: "hydrated",
+            community: "https://community.debtcollective.org",
+            homepage: "https://debtcollective.org/",
+            host: "https://community.debtcollective.org",
+            id: "dc-header"
+          });
         },
         afterRender() {
           this._super();
@@ -241,4 +250,14 @@ function loadStencilScript(src) {
   scriptNoModule.setAttribute("nomodule", "");
   scriptNoModule.setAttribute("src", src);
   document.head.appendChild(scriptNoModule);
+}
+
+function addWebComponent(tag, attrs) {
+  var component = document.createElement(tag);
+
+  Object.keys(attrs).forEach(key => {
+    component.setAttribute(key, attrs[key]);
+  });
+
+  document.body.appendChild(component);
 }

--- a/scss/widgets/header.scss
+++ b/scss/widgets/header.scss
@@ -12,6 +12,8 @@
   background: $beige;
   height: $header-height;
   margin-bottom: 0;
+  // Allow to swap by dc-header-component instead
+  visibility: hidden !important;
 
   .wrap {
     max-width: none;


### PR DESCRIPTION
**What:**
Add new header from https://github.com/debtcollective/packages/tree/development/packages/header-component

**Why:**
We want to unify the header across all the spaces within the organization

**How:**
- Visibility hidden over the built-in custom one _(we may want to delete the code if this prove to be useful and enough as it is right now)_
- Inject custom web component script using `head_tag.html`
- Add the new header using discourse slots `after_header.html`

**Media:**
_Waiting for ready to merge to upload latest_
https://www.loom.com/share/eb84a2691d3d4a14be0f99c6aab405f5

**Notes:**
- As we are not supporting env variables yet the session fetch won't work on testing environments
- [x] before merge is necessary to fix the CSS clashing issues.