### PR TITLE
Add an option for users to search content

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "pwa-chrome",
+      "request": "launch",
+      "name": "Launch Chrome against localhost",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}

--- a/javascripts/discourse/templates/components/dc-sidebar.hbs
+++ b/javascripts/discourse/templates/components/dc-sidebar.hbs
@@ -35,6 +35,19 @@
   >
     All categories
   </a>
+  <a
+    id="search-button"
+    class="sidebar-raw-link search-link"
+    href="/search"
+    title="search topics, posts, users, or categories"
+    aria-label="search topics, posts, users, or categories"
+    {{action "handleClickLink" null}}
+  >
+    <span class="material-icons icon">
+      search
+    </span>
+    Search
+  </a>
 </div>
 <ul class="list-unstyled scrollable-area">
   {{#each categories as |category|}}

--- a/scss/templates/components/dc-sidebar.scss
+++ b/scss/templates/components/dc-sidebar.scss
@@ -3,6 +3,12 @@
   position: fixed;
   width: inherit;
 
+  .search-link .icon {
+    font-size: 1.25rem;
+    display: inline-block;
+    vertical-align: middle;
+  }
+
   .scrollable-area {
     height: calc(
       100vh - #{$header-height + $dc-categories-height-base + $spacer * 3}


### PR DESCRIPTION
**What:**
Allow to community users to search after new header integration

**Why:**
After the new header integration we don't have a way to allow users to search for content

**How:**
Create a link on the sidebar in order to allow to use the advance search

> _Ideally, we wanted to move the search dropdown into a different area but the search build by discourse has been built with "Widgets" which is a custom concept from Discourse that doesn't play nice with the whole Ember ecosystem and make harder to do any customisation_

**Media:**
https://www.loom.com/share/a1cdf3ea14f745818702e129f2eaa75a