### PR TITLE
Adds 900 font weight to libre franklin

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css?family=Libre+Franklin:300,400,600");
+@import url("https://fonts.googleapis.com/css?family=Libre+Franklin:300,400,600,900");
 @import url("https://s3.amazonaws.com/tds-static/fonts/moregothic/1.0.0/More+Gothic+Bold.css");
 @import url("https://fonts.googleapis.com/icon?family=Material+Icons");
 

--- a/javascripts/discourse/initializers/dc-header.js.es6
+++ b/javascripts/discourse/initializers/dc-header.js.es6
@@ -11,7 +11,7 @@ const GUEST_LINKS = [
 
 const USER_LINKS = [
   {
-    href: "https://debtcollective.org/hub",
+    href: "https://membership.debtcollective.org/",
     text: "Member hub",
     target: "_blank"
   }


### PR DESCRIPTION
**What:**
Makes "Extra Black" weight available for Libre Franklin font.

**Why:**
The nav should render consistently across properties.

**How:**
Change to font import. 
Adding a 900 weight.